### PR TITLE
Add integration test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install install-alias clean test test-verbose test-cover test-race lint fmt vet check ci run help
+.PHONY: build install install-alias clean test test-verbose test-cover test-race test-integration test-live lint fmt vet check ci run help
 
 # Build variables
 BINARY_NAME := staghorn
@@ -54,6 +54,14 @@ test-cover-html:
 test-race:
 	go test -race -coverprofile=coverage.out ./...
 
+# Run integration tests
+test-integration:
+	go test -v ./internal/integration/...
+
+# Run live integration tests (requires gh auth)
+test-live:
+	go test -tags=live -v ./internal/integration/...
+
 # Run linter (installs golangci-lint if missing)
 lint:
 	@which golangci-lint > /dev/null || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest)
@@ -99,6 +107,8 @@ help:
 	@echo "  test-cover     Run tests with coverage"
 	@echo "  test-cover-html Generate HTML coverage report"
 	@echo "  test-race      Run tests with race detection (same as CI)"
+	@echo "  test-integration Run integration tests"
+	@echo "  test-live      Run live integration tests (requires gh auth)"
 	@echo "  lint           Run golangci-lint"
 	@echo "  fmt            Format code"
 	@echo "  vet            Run go vet"

--- a/internal/integration/assertions.go
+++ b/internal/integration/assertions.go
@@ -1,0 +1,146 @@
+package integration
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/HartBrook/staghorn/internal/merge"
+)
+
+// Asserter provides assertion helpers for CLAUDE.md output.
+type Asserter struct {
+	t       *testing.T
+	content string
+}
+
+// NewAsserter creates an asserter for the given content.
+func NewAsserter(t *testing.T, content string) *Asserter {
+	return &Asserter{t: t, content: content}
+}
+
+// HasManagedHeader checks for "<!-- Managed by staghorn" header.
+func (a *Asserter) HasManagedHeader() bool {
+	return strings.Contains(a.content, merge.HeaderManagedPrefix)
+}
+
+// HasSourceRepo checks if the header contains the expected source repo.
+func (a *Asserter) HasSourceRepo(repo string) bool {
+	return strings.Contains(a.content, "Source: "+repo)
+}
+
+// HasProvenanceMarker checks for a specific provenance marker.
+func (a *Asserter) HasProvenanceMarker(source string) bool {
+	marker := "<!-- staghorn:source:" + source + " -->"
+	return strings.Contains(a.content, marker)
+}
+
+// ProvenanceOrder returns the layers in order of appearance.
+func (a *Asserter) ProvenanceOrder() []string {
+	return merge.ListLayers(a.content)
+}
+
+// ContainsSection checks if a ## section header exists.
+func (a *Asserter) ContainsSection(header string) bool {
+	return strings.Contains(a.content, header)
+}
+
+// ContainsText checks if the content contains a substring.
+func (a *Asserter) ContainsText(text string) bool {
+	return strings.Contains(a.content, text)
+}
+
+// GetContent returns the raw content.
+func (a *Asserter) GetContent() string {
+	return a.content
+}
+
+// RunAssertions runs all assertions from a fixture definition.
+func (a *Asserter) RunAssertions(assertions FixtureAssertions) {
+	a.t.Helper()
+
+	// Check header
+	if assertions.Header != nil {
+		if assertions.Header.ManagedBy {
+			if !a.HasManagedHeader() {
+				a.t.Error("expected managed header, but not found")
+			}
+		}
+		if assertions.Header.SourceRepo != "" {
+			if !a.HasSourceRepo(assertions.Header.SourceRepo) {
+				a.t.Errorf("expected source repo %q in header, but not found", assertions.Header.SourceRepo)
+			}
+		}
+	}
+
+	// Check provenance markers
+	if assertions.Provenance != nil {
+		if assertions.Provenance.HasTeam {
+			if !a.HasProvenanceMarker("team") {
+				a.t.Error("expected team provenance marker, but not found")
+			}
+		}
+		if assertions.Provenance.HasPersonal {
+			if !a.HasProvenanceMarker("personal") {
+				a.t.Error("expected personal provenance marker, but not found")
+			}
+		}
+		if len(assertions.Provenance.Order) > 0 {
+			actual := a.ProvenanceOrder()
+			if !slices.Equal(assertions.Provenance.Order, actual) {
+				a.t.Errorf("expected provenance order %v, got %v", assertions.Provenance.Order, actual)
+			}
+		}
+	}
+
+	// Check contains
+	for _, text := range assertions.Contains {
+		if !a.ContainsText(text) {
+			a.t.Errorf("expected content to contain %q, but not found", text)
+		}
+	}
+
+	// Check not contains
+	for _, text := range assertions.NotContains {
+		if a.ContainsText(text) {
+			a.t.Errorf("expected content NOT to contain %q, but found", text)
+		}
+	}
+
+	// Check sections
+	for _, section := range assertions.Sections {
+		if !a.ContainsSection(section) {
+			a.t.Errorf("expected section %q, but not found", section)
+		}
+	}
+
+	// Check language sections
+	for _, langCheck := range assertions.Languages {
+		a.checkLanguage(langCheck)
+	}
+}
+
+// checkLanguage verifies a language section.
+func (a *Asserter) checkLanguage(check LanguageCheck) {
+	a.t.Helper()
+
+	if check.HasTeamContent {
+		marker := "<!-- staghorn:source:team:" + check.Name + " -->"
+		if !strings.Contains(a.content, marker) {
+			a.t.Errorf("expected team content for language %q, but not found", check.Name)
+		}
+	}
+
+	if check.HasPersonalContent {
+		marker := "<!-- staghorn:source:personal:" + check.Name + " -->"
+		if !strings.Contains(a.content, marker) {
+			a.t.Errorf("expected personal content for language %q, but not found", check.Name)
+		}
+	}
+
+	for _, text := range check.Contains {
+		if !strings.Contains(a.content, text) {
+			a.t.Errorf("expected language %q to contain %q, but not found", check.Name, text)
+		}
+	}
+}

--- a/internal/integration/fixtures.go
+++ b/internal/integration/fixtures.go
@@ -1,0 +1,221 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/HartBrook/staghorn/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// Fixture represents a test scenario loaded from YAML.
+type Fixture struct {
+	Name        string            `yaml:"name"`
+	Description string            `yaml:"description"`
+	Setup       FixtureSetup      `yaml:"setup"`
+	Assertions  FixtureAssertions `yaml:"assertions"`
+}
+
+// FixtureSetup defines the test environment setup.
+type FixtureSetup struct {
+	Team     *TeamSetup     `yaml:"team"`
+	Personal *PersonalSetup `yaml:"personal"`
+	Config   *ConfigSetup   `yaml:"config"`
+}
+
+// TeamSetup simulates the team repo content.
+type TeamSetup struct {
+	Source    string            `yaml:"source"`
+	ClaudeMD  string            `yaml:"claude_md"`
+	Languages map[string]string `yaml:"languages"`
+}
+
+// PersonalSetup defines personal config files.
+type PersonalSetup struct {
+	PersonalMD string            `yaml:"personal_md"`
+	Languages  map[string]string `yaml:"languages"`
+}
+
+// ConfigSetup defines the staghorn config.yaml content.
+type ConfigSetup struct {
+	Version   int             `yaml:"version"`
+	Source    string          `yaml:"source"`
+	Languages *LanguagesSetup `yaml:"languages"`
+}
+
+// LanguagesSetup defines language configuration.
+type LanguagesSetup struct {
+	Enabled  []string `yaml:"enabled"`
+	Disabled []string `yaml:"disabled"`
+}
+
+// FixtureAssertions defines what to verify.
+type FixtureAssertions struct {
+	OutputExists bool             `yaml:"output_exists"`
+	Header       *HeaderAssertion `yaml:"header"`
+	Provenance   *ProvenanceCheck `yaml:"provenance"`
+	Contains     []string         `yaml:"contains"`
+	NotContains  []string         `yaml:"not_contains"`
+	Sections     []string         `yaml:"sections"`
+	Languages    []LanguageCheck  `yaml:"languages"`
+}
+
+// HeaderAssertion checks the staghorn header.
+type HeaderAssertion struct {
+	ManagedBy  bool   `yaml:"managed_by"`
+	SourceRepo string `yaml:"source_repo"`
+}
+
+// ProvenanceCheck verifies provenance markers.
+type ProvenanceCheck struct {
+	HasTeam     bool     `yaml:"has_team"`
+	HasPersonal bool     `yaml:"has_personal"`
+	Order       []string `yaml:"order"`
+}
+
+// LanguageCheck verifies language section content.
+type LanguageCheck struct {
+	Name               string   `yaml:"name"`
+	HasTeamContent     bool     `yaml:"has_team_content"`
+	HasPersonalContent bool     `yaml:"has_personal_content"`
+	Contains           []string `yaml:"contains"`
+}
+
+// LoadFixture loads a fixture from a YAML file.
+func LoadFixture(path string) (*Fixture, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var fixture Fixture
+	if err := yaml.Unmarshal(data, &fixture); err != nil {
+		return nil, err
+	}
+
+	if err := fixture.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid fixture %s: %w", path, err)
+	}
+
+	return &fixture, nil
+}
+
+// Validate checks that the fixture has all required fields.
+func (f *Fixture) Validate() error {
+	if f.Name == "" {
+		return fmt.Errorf("missing required field: name")
+	}
+	if f.Setup.Team == nil {
+		return fmt.Errorf("missing required field: setup.team")
+	}
+	if f.Setup.Team.Source == "" {
+		return fmt.Errorf("missing required field: setup.team.source")
+	}
+	if f.Setup.Config == nil {
+		return fmt.Errorf("missing required field: setup.config")
+	}
+	return nil
+}
+
+// LoadAllFixtures loads all fixtures from a directory.
+func LoadAllFixtures(dir string) ([]*Fixture, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var fixtures []*Fixture
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if filepath.Ext(name) != ".yaml" && filepath.Ext(name) != ".yml" {
+			continue
+		}
+
+		fixture, err := LoadFixture(filepath.Join(dir, name))
+		if err != nil {
+			return nil, err
+		}
+		fixtures = append(fixtures, fixture)
+	}
+
+	return fixtures, nil
+}
+
+// ToConfig converts fixture config setup to a config.Config.
+func (c *ConfigSetup) ToConfig() *config.Config {
+	cfg := &config.Config{
+		Version: c.Version,
+		Source:  config.Source{Simple: c.Source},
+	}
+
+	if c.Languages != nil {
+		cfg.Languages.Enabled = c.Languages.Enabled
+		cfg.Languages.Disabled = c.Languages.Disabled
+	}
+
+	return cfg
+}
+
+// ApplySetup applies the fixture setup to a test environment.
+func ApplySetup(env *TestEnv, setup FixtureSetup) error {
+	if setup.Team == nil {
+		return nil
+	}
+
+	// Parse owner/repo from source
+	owner, repo := parseOwnerRepo(setup.Team.Source)
+
+	// Setup team config
+	if setup.Team.ClaudeMD != "" {
+		if err := env.SetupTeamConfig(owner, repo, setup.Team.ClaudeMD); err != nil {
+			return err
+		}
+	}
+
+	// Setup team languages
+	for lang, content := range setup.Team.Languages {
+		if err := env.SetupTeamLanguage(owner, repo, lang, content); err != nil {
+			return err
+		}
+	}
+
+	// Setup personal config
+	if setup.Personal != nil {
+		if setup.Personal.PersonalMD != "" {
+			if err := env.SetupPersonalConfig(setup.Personal.PersonalMD); err != nil {
+				return err
+			}
+		}
+
+		// Setup personal languages
+		for lang, content := range setup.Personal.Languages {
+			if err := env.SetupPersonalLanguage(lang, content); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Setup config.yaml
+	if setup.Config != nil {
+		cfg := setup.Config.ToConfig()
+		if err := env.SetupConfig(cfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// parseOwnerRepo splits "owner/repo" into owner and repo.
+func parseOwnerRepo(source string) (string, string) {
+	parts := strings.SplitN(source, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return source, ""
+}

--- a/internal/integration/harness.go
+++ b/internal/integration/harness.go
@@ -1,0 +1,175 @@
+// Package integration provides integration testing utilities for staghorn.
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/HartBrook/staghorn/internal/config"
+	"github.com/HartBrook/staghorn/internal/language"
+	"github.com/HartBrook/staghorn/internal/merge"
+	"gopkg.in/yaml.v3"
+)
+
+// TestEnv provides an isolated test environment with overridden paths.
+type TestEnv struct {
+	t         *testing.T
+	RootDir   string        // t.TempDir() root
+	HomeDir   string        // Simulated $HOME
+	ConfigDir string        // ~/.config/staghorn
+	CacheDir  string        // ~/.cache/staghorn
+	ClaudeDir string        // ~/.claude
+	Paths     *config.Paths // Configured paths pointing to temp dirs
+}
+
+// NewTestEnv creates an isolated test environment.
+// All paths are configured to use temporary directories.
+func NewTestEnv(t *testing.T) *TestEnv {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	homeDir := filepath.Join(rootDir, "home")
+	configDir := filepath.Join(homeDir, ".config", "staghorn")
+	cacheDir := filepath.Join(homeDir, ".cache", "staghorn")
+	claudeDir := filepath.Join(homeDir, ".claude")
+
+	// Create directory structure
+	for _, dir := range []string{configDir, cacheDir, claudeDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("failed to create directory %s: %v", dir, err)
+		}
+	}
+
+	paths := config.NewPathsWithOverrides(configDir, cacheDir)
+
+	return &TestEnv{
+		t:         t,
+		RootDir:   rootDir,
+		HomeDir:   homeDir,
+		ConfigDir: configDir,
+		CacheDir:  cacheDir,
+		ClaudeDir: claudeDir,
+		Paths:     paths,
+	}
+}
+
+// Cleanup is a no-op retained for API compatibility.
+// Temporary directories are automatically cleaned up by t.TempDir().
+func (e *TestEnv) Cleanup() {}
+
+// SetupTeamConfig writes team CLAUDE.md to cache (simulates fetch).
+func (e *TestEnv) SetupTeamConfig(owner, repo, content string) error {
+	cacheFile := e.Paths.CacheFile(owner, repo)
+	return os.WriteFile(cacheFile, []byte(content), 0644)
+}
+
+// SetupTeamLanguage writes a team language config to cache.
+func (e *TestEnv) SetupTeamLanguage(owner, repo, lang, content string) error {
+	langDir := e.Paths.TeamLanguagesDir(owner, repo)
+	if err := os.MkdirAll(langDir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(langDir, lang+".md"), []byte(content), 0644)
+}
+
+// SetupPersonalConfig writes personal.md.
+func (e *TestEnv) SetupPersonalConfig(content string) error {
+	return os.WriteFile(e.Paths.PersonalMD, []byte(content), 0644)
+}
+
+// SetupPersonalLanguage writes a personal language config.
+func (e *TestEnv) SetupPersonalLanguage(lang, content string) error {
+	if err := os.MkdirAll(e.Paths.PersonalLanguages, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(e.Paths.PersonalLanguages, lang+".md"), []byte(content), 0644)
+}
+
+// SetupConfig writes config.yaml.
+func (e *TestEnv) SetupConfig(cfg *config.Config) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(e.Paths.ConfigFile, data, 0644)
+}
+
+// GetOutputPath returns the path to ~/.claude/CLAUDE.md.
+func (e *TestEnv) GetOutputPath() string {
+	return filepath.Join(e.ClaudeDir, "CLAUDE.md")
+}
+
+// ReadOutput reads the final CLAUDE.md output.
+func (e *TestEnv) ReadOutput() (string, error) {
+	content, err := os.ReadFile(e.GetOutputPath())
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+// RunSync executes the merge and write operation with the current test environment.
+// This replicates the core logic of applyConfig without the interactive prompts.
+func (e *TestEnv) RunSync(owner, repo string, cfg *config.Config) error {
+	// Read team config from cache
+	teamConfig, err := os.ReadFile(e.Paths.CacheFile(owner, repo))
+	if err != nil {
+		return err
+	}
+
+	// Read personal config (optional)
+	var personalConfig []byte
+	if _, err := os.Stat(e.Paths.PersonalMD); err == nil {
+		personalConfig, err = os.ReadFile(e.Paths.PersonalMD)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Resolve languages
+	teamLangDir := e.Paths.TeamLanguagesDir(owner, repo)
+	personalLangDir := e.Paths.PersonalLanguages
+
+	var activeLanguages []string
+	var languageFiles map[string][]*language.LanguageFile
+
+	if len(cfg.Languages.Enabled) > 0 {
+		activeLanguages = language.FilterDisabled(cfg.Languages.Enabled, cfg.Languages.Disabled)
+	} else {
+		available, listErr := language.ListAvailableLanguages(teamLangDir, personalLangDir, "")
+		if listErr != nil {
+			return listErr
+		}
+		activeLanguages = language.FilterDisabled(available, cfg.Languages.Disabled)
+	}
+
+	if len(activeLanguages) > 0 {
+		var err error
+		languageFiles, err = language.LoadLanguageFiles(
+			activeLanguages,
+			teamLangDir,
+			personalLangDir,
+			"",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Merge configs
+	layers := []merge.Layer{
+		{Content: string(teamConfig), Source: "team"},
+		{Content: string(personalConfig), Source: "personal"},
+	}
+	mergeOpts := merge.MergeOptions{
+		AnnotateSources: true,
+		SourceRepo:      cfg.SourceRepo(),
+		Languages:       activeLanguages,
+		LanguageFiles:   languageFiles,
+	}
+	output := merge.MergeWithLanguages(layers, mergeOpts)
+
+	// Write to output
+	return os.WriteFile(e.GetOutputPath(), []byte(output), 0644)
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1,0 +1,321 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/HartBrook/staghorn/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getTestdataDir returns the path to the testdata directory.
+func getTestdataDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "testdata", "fixtures")
+}
+
+// TestIntegration_Fixtures runs all fixture-based integration tests.
+func TestIntegration_Fixtures(t *testing.T) {
+	fixturesDir := getTestdataDir()
+
+	// Check if fixtures directory exists
+	if _, err := os.Stat(fixturesDir); os.IsNotExist(err) {
+		t.Skip("fixtures directory not found")
+	}
+
+	fixtures, err := LoadAllFixtures(fixturesDir)
+	require.NoError(t, err, "failed to load fixtures")
+
+	if len(fixtures) == 0 {
+		t.Skip("no fixtures found")
+	}
+
+	for _, fixture := range fixtures {
+		fixture := fixture // capture for parallel execution
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+			runFixture(t, fixture)
+		})
+	}
+}
+
+// runFixture executes a single fixture test.
+func runFixture(t *testing.T, fixture *Fixture) {
+	t.Helper()
+
+	// Validate fixture has required fields
+	require.NotNil(t, fixture.Setup.Team, "fixture must have team setup")
+	require.NotNil(t, fixture.Setup.Config, "fixture must have config setup")
+
+	// Create isolated environment
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	// Apply setup
+	err := ApplySetup(env, fixture.Setup)
+	require.NoError(t, err, "failed to apply setup")
+
+	// Get owner/repo from config
+	owner, repo := parseOwnerRepo(fixture.Setup.Team.Source)
+
+	// Get config
+	cfg := fixture.Setup.Config.ToConfig()
+
+	// Run sync
+	err = env.RunSync(owner, repo, cfg)
+	require.NoError(t, err, "RunSync failed")
+
+	// Check output exists
+	if fixture.Assertions.OutputExists {
+		_, err := os.Stat(env.GetOutputPath())
+		require.NoError(t, err, "output file should exist")
+	}
+
+	// Read output and run assertions
+	output, err := env.ReadOutput()
+	require.NoError(t, err, "failed to read output")
+
+	asserter := NewAsserter(t, output)
+	asserter.RunAssertions(fixture.Assertions)
+}
+
+// TestIntegration_BasicSync tests basic team config sync without fixtures.
+func TestIntegration_BasicSync(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+	teamContent := `## Code Style
+
+Follow team standards.
+
+## Testing
+
+Write tests for everything.`
+
+	err := env.SetupTeamConfig(owner, repo, teamContent)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Version: 1,
+		Source:  config.Source{Simple: owner + "/" + repo},
+	}
+	err = env.SetupConfig(cfg)
+	require.NoError(t, err)
+
+	err = env.RunSync(owner, repo, cfg)
+	require.NoError(t, err)
+
+	output, err := env.ReadOutput()
+	require.NoError(t, err)
+
+	asserter := NewAsserter(t, output)
+
+	// Verify header
+	assert.True(t, asserter.HasManagedHeader(), "should have managed header")
+	assert.True(t, asserter.HasSourceRepo(owner+"/"+repo), "should have source repo in header")
+
+	// Verify provenance
+	assert.True(t, asserter.HasProvenanceMarker("team"), "should have team marker")
+
+	// Verify content
+	assert.True(t, asserter.ContainsText("Follow team standards"), "should contain team content")
+	assert.True(t, asserter.ContainsText("Write tests for everything"), "should contain team content")
+}
+
+// TestIntegration_TeamPlusPersonal tests merging team and personal configs.
+func TestIntegration_TeamPlusPersonal(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+	teamContent := `## Code Style
+
+Follow team standards.`
+
+	personalContent := `## Code Style
+
+My personal preferences.
+
+## My Preferences
+
+Custom section.`
+
+	err := env.SetupTeamConfig(owner, repo, teamContent)
+	require.NoError(t, err)
+
+	err = env.SetupPersonalConfig(personalContent)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Version: 1,
+		Source:  config.Source{Simple: owner + "/" + repo},
+	}
+	err = env.SetupConfig(cfg)
+	require.NoError(t, err)
+
+	err = env.RunSync(owner, repo, cfg)
+	require.NoError(t, err)
+
+	output, err := env.ReadOutput()
+	require.NoError(t, err)
+
+	asserter := NewAsserter(t, output)
+
+	// Verify both markers present
+	assert.True(t, asserter.HasProvenanceMarker("team"), "should have team marker")
+	assert.True(t, asserter.HasProvenanceMarker("personal"), "should have personal marker")
+
+	// Verify provenance order
+	order := asserter.ProvenanceOrder()
+	assert.Equal(t, []string{"team", "personal"}, order, "team should come before personal")
+
+	// Verify content from both layers
+	assert.True(t, asserter.ContainsText("Follow team standards"), "should contain team content")
+	assert.True(t, asserter.ContainsText("My personal preferences"), "should contain personal content")
+	assert.True(t, asserter.ContainsText("Custom section"), "should contain personal-only section")
+}
+
+// TestIntegration_WithLanguages tests language config merging.
+func TestIntegration_WithLanguages(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+	teamContent := `## Code Style
+
+Team rules.`
+
+	teamPython := `## Python Guidelines
+
+Use type hints.`
+
+	personalPython := `## My Python Preferences
+
+Prefer dataclasses.`
+
+	err := env.SetupTeamConfig(owner, repo, teamContent)
+	require.NoError(t, err)
+
+	err = env.SetupTeamLanguage(owner, repo, "python", teamPython)
+	require.NoError(t, err)
+
+	err = env.SetupPersonalLanguage("python", personalPython)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Version: 1,
+		Source:  config.Source{Simple: owner + "/" + repo},
+	}
+	err = env.SetupConfig(cfg)
+	require.NoError(t, err)
+
+	err = env.RunSync(owner, repo, cfg)
+	require.NoError(t, err)
+
+	output, err := env.ReadOutput()
+	require.NoError(t, err)
+
+	asserter := NewAsserter(t, output)
+
+	// Verify language markers
+	assert.True(t, strings.Contains(output, "<!-- staghorn:source:team:python -->"), "should have team python marker")
+	assert.True(t, strings.Contains(output, "<!-- staghorn:source:personal:python -->"), "should have personal python marker")
+
+	// Verify language content
+	assert.True(t, asserter.ContainsText("Use type hints"), "should contain team python content")
+	assert.True(t, asserter.ContainsText("Prefer dataclasses"), "should contain personal python content")
+}
+
+// TestIntegration_EmptyPersonal tests sync with no personal config.
+func TestIntegration_EmptyPersonal(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+	teamContent := `## Code Style
+
+Team rules only.`
+
+	err := env.SetupTeamConfig(owner, repo, teamContent)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Version: 1,
+		Source:  config.Source{Simple: owner + "/" + repo},
+	}
+	err = env.SetupConfig(cfg)
+	require.NoError(t, err)
+
+	err = env.RunSync(owner, repo, cfg)
+	require.NoError(t, err)
+
+	output, err := env.ReadOutput()
+	require.NoError(t, err)
+
+	asserter := NewAsserter(t, output)
+
+	// Should have team marker but no personal marker
+	assert.True(t, asserter.HasProvenanceMarker("team"), "should have team marker")
+	assert.False(t, asserter.HasProvenanceMarker("personal"), "should NOT have personal marker")
+
+	// Verify content
+	assert.True(t, asserter.ContainsText("Team rules only"), "should contain team content")
+}
+
+// TestIntegration_ProvenanceOrder tests that team content appears before personal.
+func TestIntegration_ProvenanceOrder(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+
+	// Team has Section A
+	teamContent := `## Section A
+
+Team content for A.`
+
+	// Personal has Section A additions and new Section B
+	personalContent := `## Section A
+
+Personal additions for A.
+
+## Section B
+
+Personal-only section.`
+
+	err := env.SetupTeamConfig(owner, repo, teamContent)
+	require.NoError(t, err)
+
+	err = env.SetupPersonalConfig(personalContent)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Version: 1,
+		Source:  config.Source{Simple: owner + "/" + repo},
+	}
+	err = env.SetupConfig(cfg)
+	require.NoError(t, err)
+
+	err = env.RunSync(owner, repo, cfg)
+	require.NoError(t, err)
+
+	output, err := env.ReadOutput()
+	require.NoError(t, err)
+
+	// Team marker should appear before personal marker
+	teamIdx := strings.Index(output, "<!-- staghorn:source:team -->")
+	personalIdx := strings.Index(output, "<!-- staghorn:source:personal -->")
+
+	assert.Greater(t, personalIdx, teamIdx, "team marker should appear before personal marker")
+
+	// Team content should appear before personal content in same section
+	teamContentIdx := strings.Index(output, "Team content for A")
+	personalContentIdx := strings.Index(output, "Personal additions for A")
+
+	assert.Greater(t, personalContentIdx, teamContentIdx, "team content should appear before personal additions")
+}

--- a/internal/integration/live_test.go
+++ b/internal/integration/live_test.go
@@ -1,0 +1,130 @@
+//go:build live
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HartBrook/staghorn/internal/config"
+	"github.com/HartBrook/staghorn/internal/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLive_CommunityRepo tests against the real staghorn-community repo.
+// Run with: go test -tags=live ./internal/integration/...
+func TestLive_CommunityRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live test in short mode")
+	}
+
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	// Create GitHub client
+	client, err := github.NewClient()
+	if err != nil {
+		t.Skip("GitHub auth not available, skipping live test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	owner, repo := "HartBrook", "staghorn-community"
+
+	// Fetch real content
+	result, err := client.FetchFile(ctx, owner, repo, "CLAUDE.md", "")
+	if err != nil {
+		t.Skipf("Failed to fetch from GitHub (may be rate limited): %v", err)
+	}
+
+	// Setup test environment with real content
+	err = env.SetupTeamConfig(owner, repo, result.Content)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Version: 1,
+		Source:  config.Source{Simple: owner + "/" + repo},
+	}
+	err = env.SetupConfig(cfg)
+	require.NoError(t, err)
+
+	// Run sync
+	err = env.RunSync(owner, repo, cfg)
+	require.NoError(t, err)
+
+	// Read and verify output
+	output, err := env.ReadOutput()
+	require.NoError(t, err)
+
+	asserter := NewAsserter(t, output)
+
+	// Verify basic structure
+	assert.True(t, asserter.HasManagedHeader(), "should have managed header")
+	assert.True(t, asserter.HasSourceRepo(owner+"/"+repo), "should have correct source repo")
+	assert.True(t, asserter.HasProvenanceMarker("team"), "should have team marker")
+
+	// Verify some expected content from community standards
+	assert.True(t, asserter.ContainsSection("## Core Principles") || asserter.ContainsSection("## Code"), "should have main section headers")
+}
+
+// TestLive_WithLanguages tests fetching language configs from the community repo.
+// Run with: go test -tags=live ./internal/integration/...
+func TestLive_WithLanguages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live test in short mode")
+	}
+
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	// Create GitHub client
+	client, err := github.NewClient()
+	if err != nil {
+		t.Skip("GitHub auth not available, skipping live test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	owner, repo := "HartBrook", "staghorn-community"
+
+	// Fetch main CLAUDE.md
+	result, err := client.FetchFile(ctx, owner, repo, "CLAUDE.md", "")
+	if err != nil {
+		t.Skipf("Failed to fetch from GitHub: %v", err)
+	}
+
+	err = env.SetupTeamConfig(owner, repo, result.Content)
+	require.NoError(t, err)
+
+	// Try to fetch python language config
+	pythonResult, err := client.FetchFile(ctx, owner, repo, "languages/python.md", "")
+	if err == nil {
+		err = env.SetupTeamLanguage(owner, repo, "python", pythonResult.Content)
+		require.NoError(t, err)
+	}
+
+	cfg := &config.Config{
+		Version: 1,
+		Source:  config.Source{Simple: owner + "/" + repo},
+	}
+	err = env.SetupConfig(cfg)
+	require.NoError(t, err)
+
+	// Run sync
+	err = env.RunSync(owner, repo, cfg)
+	require.NoError(t, err)
+
+	// Read output
+	output, err := env.ReadOutput()
+	require.NoError(t, err)
+
+	asserter := NewAsserter(t, output)
+
+	// Verify output has expected structure
+	assert.True(t, asserter.HasManagedHeader(), "should have managed header")
+	assert.True(t, asserter.HasProvenanceMarker("team"), "should have team marker")
+}

--- a/internal/integration/testdata/fixtures/basic_sync.yaml
+++ b/internal/integration/testdata/fixtures/basic_sync.yaml
@@ -1,0 +1,34 @@
+name: "basic_sync"
+description: "Basic team config sync with provenance markers"
+
+setup:
+  team:
+    source: "acme/standards"
+    claude_md: |
+      ## Code Style
+
+      Follow team standards.
+
+      ## Testing
+
+      Write tests for everything.
+
+  config:
+    version: 1
+    source: "acme/standards"
+
+assertions:
+  output_exists: true
+  header:
+    managed_by: true
+    source_repo: "acme/standards"
+  provenance:
+    has_team: true
+    has_personal: false
+  contains:
+    - "Follow team standards"
+    - "Write tests for everything"
+    - "<!-- staghorn:source:team -->"
+  sections:
+    - "## Code Style"
+    - "## Testing"

--- a/internal/integration/testdata/fixtures/provenance_order.yaml
+++ b/internal/integration/testdata/fixtures/provenance_order.yaml
@@ -1,0 +1,49 @@
+name: "provenance_order"
+description: "Team content appears before personal in same section"
+
+setup:
+  team:
+    source: "testorg/testrepo"
+    claude_md: |
+      ## Section A
+
+      Team content for section A.
+
+      ## Section B
+
+      Team content for section B.
+
+  personal:
+    personal_md: |
+      ## Section A
+
+      Personal additions to section A.
+
+      ## Section C
+
+      Personal-only section C.
+
+  config:
+    version: 1
+    source: "testorg/testrepo"
+
+assertions:
+  output_exists: true
+  header:
+    managed_by: true
+    source_repo: "testorg/testrepo"
+  provenance:
+    has_team: true
+    has_personal: true
+    order:
+      - "team"
+      - "personal"
+  contains:
+    - "Team content for section A"
+    - "Personal additions to section A"
+    - "Team content for section B"
+    - "Personal-only section C"
+  sections:
+    - "## Section A"
+    - "## Section B"
+    - "## Section C"

--- a/internal/integration/testdata/fixtures/with_languages.yaml
+++ b/internal/integration/testdata/fixtures/with_languages.yaml
@@ -1,0 +1,56 @@
+name: "with_languages"
+description: "Team and personal language configs merged correctly"
+
+setup:
+  team:
+    source: "acme/standards"
+    claude_md: |
+      ## Code Style
+
+      Team rules.
+    languages:
+      python: |
+        ## Python Guidelines
+
+        Use type hints for all functions.
+        Use ruff for linting.
+      go: |
+        ## Go Guidelines
+
+        Use gofmt.
+        Handle errors explicitly.
+
+  personal:
+    languages:
+      python: |
+        ## My Python Preferences
+
+        Prefer dataclasses over dicts.
+
+  config:
+    version: 1
+    source: "acme/standards"
+
+assertions:
+  output_exists: true
+  header:
+    managed_by: true
+  provenance:
+    has_team: true
+  contains:
+    - "Team rules"
+    - "Use type hints"
+    - "Use gofmt"
+    - "Prefer dataclasses"
+  languages:
+    - name: "python"
+      has_team_content: true
+      has_personal_content: true
+      contains:
+        - "Use type hints"
+        - "Prefer dataclasses"
+    - name: "go"
+      has_team_content: true
+      has_personal_content: false
+      contains:
+        - "Use gofmt"

--- a/internal/integration/testdata/fixtures/with_personal.yaml
+++ b/internal/integration/testdata/fixtures/with_personal.yaml
@@ -1,0 +1,50 @@
+name: "with_personal"
+description: "Team config with personal additions merged"
+
+setup:
+  team:
+    source: "acme/standards"
+    claude_md: |
+      ## Code Style
+
+      Follow team standards.
+
+      ## Testing
+
+      Write tests for everything.
+
+  personal:
+    personal_md: |
+      ## Code Style
+
+      My personal preferences for code style.
+
+      ## My Preferences
+
+      Custom personal section.
+
+  config:
+    version: 1
+    source: "acme/standards"
+
+assertions:
+  output_exists: true
+  header:
+    managed_by: true
+    source_repo: "acme/standards"
+  provenance:
+    has_team: true
+    has_personal: true
+    order:
+      - "team"
+      - "personal"
+  contains:
+    - "Follow team standards"
+    - "My personal preferences"
+    - "Custom personal section"
+    - "<!-- staghorn:source:team -->"
+    - "<!-- staghorn:source:personal -->"
+  sections:
+    - "## Code Style"
+    - "## Testing"
+    - "## My Preferences"


### PR DESCRIPTION
## Summary

- Add YAML-driven integration test framework in `internal/integration/`
- Include test harness with filesystem isolation (`t.TempDir()`)
- Add fixture-based tests for sync scenarios (basic, with personal, with languages, provenance order)
- Add live tests (behind `live` build tag) for real GitHub API validation
- Update Makefile with `test-integration` and `test-live` targets
- Document integration testing in CONTRIBUTING.md

## Test plan

- [ ] Run `make test-integration` to verify mocked tests pass
- [ ] Run `make test-live` with GitHub auth to verify live tests
- [ ] Review fixture YAML files for completeness