### PR TITLE
Add path-scoped rules feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,12 @@ your-org/claude-standards/
 ├── languages/          # Language-specific configs (optional)
 │   ├── python.md
 │   └── go.md
+├── rules/              # Path-scoped rules (optional)
+│   ├── security.md
+│   ├── api/
+│   │   └── rest.md
+│   └── frontend/
+│       └── react.md
 ├── evals/              # Behavioral tests (optional)
 │   ├── security-secrets.yaml
 │   └── code-quality.yaml
@@ -529,6 +535,89 @@ languages:
 | Kotlin     | `build.gradle.kts`                                          |
 
 > When both TypeScript and JavaScript are detected, TypeScript takes precedence.
+
+## Path-Scoped Rules
+
+Rules are guidelines that Claude Code applies only when working with specific file types or directories. Unlike the main `CLAUDE.md` which applies globally, rules use path patterns to scope their applicability.
+
+### How Rules Work
+
+Rules are markdown files in `rules/` directories with optional YAML frontmatter specifying path patterns:
+
+```markdown
+---
+paths:
+  - "src/api/**/*.ts"
+  - "src/routes/**/*.ts"
+---
+# REST API Standards
+
+Use proper HTTP methods and status codes.
+```
+
+When you edit a file matching `src/api/**/*.ts`, Claude Code automatically includes these guidelines.
+
+### Rule Sources
+
+Rules layer just like other configs (higher precedence wins):
+
+| Source       | Location                     | Use case               |
+| ------------ | ---------------------------- | ---------------------- |
+| **Project**  | `.staghorn/rules/`           | Project-specific rules |
+| **Personal** | `~/.config/staghorn/rules/`  | Your custom rules      |
+| **Team**     | `rules/` in source repo      | Shared team rules      |
+| **Starter**  | Built-in                     | Common baseline rules  |
+
+Personal rules override team rules with the same relative path (e.g., `security.md`).
+
+### Starter Rules
+
+Staghorn includes starter rules you can use as a starting point:
+
+| Rule                  | Paths                          | Guidelines                    |
+| --------------------- | ------------------------------ | ----------------------------- |
+| `security.md`         | All files                      | Secrets, input validation     |
+| `testing.md`          | All files                      | Test coverage, quality        |
+| `api/rest.md`         | `src/api/**`, `src/routes/**`  | HTTP methods, status codes    |
+| `frontend/react.md`   | `src/components/**`, `app/**`  | Component design, performance |
+| `error-handling.md`   | All files                      | Error handling patterns       |
+
+### Creating Rules
+
+Create a rule file in `rules/` (team) or `~/.config/staghorn/rules/` (personal):
+
+```markdown
+---
+paths:
+  - "src/database/**/*.ts"
+  - "src/db/**/*.ts"
+---
+# Database Guidelines
+
+- Use parameterized queries to prevent SQL injection
+- Always handle connection errors gracefully
+- Use transactions for multi-step operations
+```
+
+Rules without `paths:` frontmatter apply to all files.
+
+### Subdirectory Organization
+
+Organize rules in subdirectories for clarity:
+
+```
+rules/
+├── security.md          # General security (all files)
+├── api/
+│   └── rest.md          # REST API guidelines
+├── frontend/
+│   ├── react.md         # React components
+│   └── accessibility.md # A11y guidelines
+└── database/
+    └── queries.md       # Database patterns
+```
+
+The subdirectory structure is preserved when syncing to `~/.claude/rules/`.
 
 ## Creating Commands
 
@@ -722,14 +811,17 @@ languages:
 | `~/.config/staghorn/personal.md` | Your personal additions               |
 | `~/.config/staghorn/commands/`   | Personal commands                     |
 | `~/.config/staghorn/languages/`  | Personal language configs             |
+| `~/.config/staghorn/rules/`      | Personal rules                        |
 | `~/.config/staghorn/evals/`      | Personal evals                        |
 | `~/.config/staghorn/optimized/`  | Cached optimization results           |
 | `~/.cache/staghorn/`             | Cached team/community configs         |
 | `~/.claude/CLAUDE.md`            | **Output** — merged global config     |
+| `~/.claude/rules/`               | **Output** — synced rules             |
 | `.staghorn/project.md`           | Project config source (you edit this) |
 | `.staghorn/source.yaml`          | Source repo marker (team repos only)  |
 | `.staghorn/commands/`            | Project-specific commands             |
 | `.staghorn/languages/`           | Project-specific language configs     |
+| `.staghorn/rules/`               | Project-specific rules                |
 | `.staghorn/evals/`               | Project-specific evals                |
 | `./CLAUDE.md`                    | **Output** — merged project config    |
 
@@ -784,9 +876,10 @@ stag sync --fetch-only     # Fetch without applying
 stag sync --apply-only     # Apply cached config without fetching
 stag sync --force          # Re-fetch even if cache is fresh
 stag sync --offline        # Use cached config only (no network)
-stag sync --config-only    # Sync config only, skip commands/languages
+stag sync --config-only    # Sync config only, skip commands/languages/rules
 stag sync --commands-only  # Sync commands only
 stag sync --languages-only # Sync language configs only
+stag sync --rules-only     # Sync rules only
 
 # Search options
 stag search --lang go      # Filter by language

--- a/README.md
+++ b/README.md
@@ -497,17 +497,16 @@ Language configs are markdown files in `languages/` directories, layered just li
 2. **Personal** — `~/.config/staghorn/languages/`
 3. **Project** — `.staghorn/languages/`
 
-### Global vs Project
+### What Gets Included
 
-- **Global (`~/.claude/CLAUDE.md`)**: Includes all available language configs
-- **Project (`./CLAUDE.md`)**: Auto-detects languages from marker files (e.g., `go.mod`, `pyproject.toml`)
+By default, `stag sync` includes all language configs that exist in your team, personal, or project `languages/` directories. If your team provides `python.md` and `go.md`, both are included in the merged output.
 
-### Configuration Options
+Use `enabled` or `disabled` to control which languages are included:
 
 ```yaml
 # ~/.config/staghorn/config.yaml
 
-# Only include specific languages globally
+# Only include specific languages
 languages:
   enabled:
     - python
@@ -519,7 +518,9 @@ languages:
     - javascript
 ```
 
-### Supported Languages
+### Language Detection (Informational)
+
+The `stag languages` command detects languages in your project based on marker files. This is useful for seeing what languages are present, but doesn't affect which configs are synced.
 
 | Language   | Marker Files                                                |
 | ---------- | ----------------------------------------------------------- |
@@ -534,11 +535,32 @@ languages:
 | Swift      | `Package.swift`                                             |
 | Kotlin     | `build.gradle.kts`                                          |
 
-> When both TypeScript and JavaScript are detected, TypeScript takes precedence.
+> When both TypeScript and JavaScript are detected, TypeScript takes precedence in the display.
 
 ## Path-Scoped Rules
 
 Rules are guidelines that Claude Code applies only when working with specific file types or directories. Unlike the main `CLAUDE.md` which applies globally, rules use path patterns to scope their applicability.
+
+### Rules vs Languages
+
+Both features provide scoped guidelines, but they solve different problems:
+
+| Feature | Scoping | Best For |
+|---------|---------|----------|
+| **Languages** | Included if config file exists (`languages/python.md`) | Language-specific conventions, tooling, idioms |
+| **Rules** | Path patterns in frontmatter (`src/api/**/*.ts`) | Architectural patterns, domain-specific guidelines |
+
+**Use Languages when** the guidance is tied to a programming language:
+- Python type hints and testing with pytest
+- Go error handling conventions
+- TypeScript strict mode settings
+
+**Use Rules when** the guidance is tied to a location or domain:
+- REST API standards for `src/api/**`
+- Database query patterns for `src/db/**`
+- React component guidelines for `src/components/**`
+
+They work together: a Python API project might use the `python` language config for Python conventions *and* the `api/rest.md` rule for REST patterns.
 
 ### How Rules Work
 

--- a/example/README.md
+++ b/example/README.md
@@ -20,6 +20,13 @@ team-repo/
 │   ├── refactor.md        # Suggest refactoring improvements
 │   ├── security-audit.md  # Security vulnerability scan
 │   └── test-gen.md        # Generate unit tests
+├── rules/                 # Path-scoped rules
+│   ├── security.md        # Security guidelines (all files)
+│   ├── testing.md         # Testing standards (all files)
+│   ├── api/
+│   │   └── rest.md        # REST API standards (api paths)
+│   └── frontend/
+│       └── react.md       # React guidelines (component paths)
 ├── evals/                 # Behavioral tests
 │   ├── team-security.yaml # Security guidelines tests
 │   ├── team-quality.yaml  # Code quality tests
@@ -47,6 +54,7 @@ To use this as your team's standards repo:
 ## Customization
 
 - **CLAUDE.md**: Add your team's general coding standards
+- **rules/**: Add path-scoped rules for specific file types or directories
 - **evals/**: Write tests to verify Claude follows your guidelines
 - **languages/**: Add configs for languages your team uses
 - **commands/**: Create prompts for common workflows
@@ -57,4 +65,5 @@ To use this as your team's standards repo:
 - Keep guidelines concise and actionable
 - Update regularly based on team feedback
 - Use commands for repetitive tasks
+- Use rules with path patterns for file-specific guidelines
 - Language configs should complement, not repeat, the main CLAUDE.md

--- a/example/team-repo/rules/api/rest.md
+++ b/example/team-repo/rules/api/rest.md
@@ -1,0 +1,54 @@
+---
+paths:
+  - "src/api/**/*.ts"
+  - "src/api/**/*.js"
+  - "src/routes/**/*.ts"
+  - "src/routes/**/*.js"
+  - "api/**/*.py"
+  - "app/api/**/*.py"
+  - "internal/api/**/*.go"
+  - "pkg/api/**/*.go"
+---
+# REST API Standards
+
+## HTTP Methods
+
+- Use GET for retrieving resources (idempotent, cacheable)
+- Use POST for creating new resources
+- Use PUT for full resource replacement
+- Use PATCH for partial updates
+- Use DELETE for removing resources
+
+## Status Codes
+
+- 2xx for successful operations (200 OK, 201 Created, 204 No Content)
+- 4xx for client errors (400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found, 422 Unprocessable Entity)
+- 5xx for server errors (500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable)
+
+## Request/Response
+
+- Validate all request input before processing
+- Use consistent error response format with error codes and messages
+- Include pagination for list endpoints (limit, offset or cursor-based)
+- Version APIs in the URL path (/v1/, /v2/) or via Accept headers
+- Use JSON for request and response bodies
+
+## Error Responses
+
+Return errors in a consistent format:
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid request parameters",
+    "details": [...]
+  }
+}
+```
+
+## Documentation
+
+- Document endpoints with OpenAPI/Swagger specifications
+- Include request/response examples for each endpoint
+- Document authentication requirements
+- List all possible error responses with their codes

--- a/example/team-repo/rules/frontend/react.md
+++ b/example/team-repo/rules/frontend/react.md
@@ -1,0 +1,49 @@
+---
+paths:
+  - "src/components/**/*.tsx"
+  - "src/components/**/*.jsx"
+  - "src/pages/**/*.tsx"
+  - "src/pages/**/*.jsx"
+  - "app/**/*.tsx"
+  - "app/**/*.jsx"
+---
+# React Guidelines
+
+## Component Design
+
+- Use functional components with hooks
+- Keep components small and focused (under 100 lines)
+- Extract reusable logic into custom hooks
+- Prefer composition over inheritance
+- Use TypeScript for type safety
+
+## Props and State
+
+- Define explicit prop types with TypeScript interfaces
+- Keep state as local as possible
+- Lift state up only when necessary for sharing
+- Use context sparingly for truly global state
+- Consider state management libraries for complex state
+
+## Performance
+
+- Memoize expensive calculations with useMemo
+- Memoize callbacks passed to children with useCallback
+- Use React.memo for components that render often with same props
+- Avoid inline object/array creation in render
+- Lazy load components and routes when appropriate
+
+## Accessibility
+
+- Use semantic HTML elements
+- Include proper ARIA attributes when needed
+- Ensure keyboard navigation works
+- Maintain sufficient color contrast
+- Test with screen readers
+
+## Testing
+
+- Test component behavior, not implementation
+- Use React Testing Library for component tests
+- Test user interactions and accessibility
+- Colocate tests with components

--- a/example/team-repo/rules/security.md
+++ b/example/team-repo/rules/security.md
@@ -1,0 +1,31 @@
+# Security Guidelines
+
+## Secrets and Credentials
+
+- Never commit secrets, API keys, or credentials to version control
+- Use environment variables or secret managers for sensitive configuration
+- Add secret patterns to `.gitignore` (e.g., `.env`, `*.key`, `credentials.json`)
+- Rotate credentials regularly and after any potential exposure
+
+## Input Validation
+
+- Validate and sanitize all external input at system boundaries
+- Use parameterized queries for database access to prevent SQL injection
+- Escape output appropriately to prevent XSS attacks
+- Validate file paths to prevent path traversal attacks
+- Implement rate limiting for public endpoints
+
+## Authentication and Authorization
+
+- Apply the principle of least privilege
+- Validate authentication tokens on every request
+- Use secure session management practices
+- Implement proper CORS policies
+- Log security-relevant events for audit trails
+
+## Dependencies
+
+- Keep dependencies updated to patch known vulnerabilities
+- Use lock files to ensure reproducible builds
+- Review dependency changes before updating
+- Use automated vulnerability scanning in CI/CD

--- a/example/team-repo/rules/testing.md
+++ b/example/team-repo/rules/testing.md
@@ -1,0 +1,31 @@
+# Testing Standards
+
+## Test Coverage
+
+- Write tests for new functionality and bug fixes
+- Test behavior, not implementation details
+- Cover error paths and edge cases, not just happy paths
+- Aim for meaningful coverage, not just high percentages
+
+## Test Quality
+
+- Keep tests deterministic; avoid flaky tests that depend on timing or external state
+- Use descriptive test names that explain the scenario and expected outcome
+- Isolate tests; each test should set up its own state
+- Clean up test resources after each test
+- Test one thing per test case
+
+## Test Organization
+
+- Colocate tests with the code they test when possible
+- Group related tests logically using describe/context blocks
+- Use test fixtures for complex setup scenarios
+- Mock external dependencies at system boundaries
+- Use factories or builders for test data creation
+
+## Integration Tests
+
+- Test critical user flows end-to-end
+- Use realistic test data
+- Test against actual dependencies when feasible
+- Include performance benchmarks for critical paths

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -16,6 +16,7 @@ type Paths struct {
 	PersonalCommands  string // ~/.config/staghorn/commands
 	PersonalLanguages string // ~/.config/staghorn/languages
 	PersonalEvals     string // ~/.config/staghorn/evals
+	PersonalRules     string // ~/.config/staghorn/rules
 }
 
 // NewPaths creates Paths using ~/.config and ~/.cache directories.
@@ -34,6 +35,7 @@ func NewPaths() *Paths {
 		PersonalCommands:  filepath.Join(configDir, "commands"),
 		PersonalLanguages: filepath.Join(configDir, "languages"),
 		PersonalEvals:     filepath.Join(configDir, "evals"),
+		PersonalRules:     filepath.Join(configDir, "rules"),
 	}
 }
 
@@ -47,6 +49,7 @@ func NewPathsWithOverrides(configDir, cacheDir string) *Paths {
 		PersonalCommands:  filepath.Join(configDir, "commands"),
 		PersonalLanguages: filepath.Join(configDir, "languages"),
 		PersonalEvals:     filepath.Join(configDir, "evals"),
+		PersonalRules:     filepath.Join(configDir, "rules"),
 	}
 }
 
@@ -80,6 +83,11 @@ func (p *Paths) TeamEvalsDir(owner, repo string) string {
 	return filepath.Join(p.CacheDir, fmt.Sprintf("%s-%s-evals", owner, repo))
 }
 
+// TeamRulesDir returns the path for cached team rules.
+func (p *Paths) TeamRulesDir(owner, repo string) string {
+	return filepath.Join(p.CacheDir, fmt.Sprintf("%s-%s-rules", owner, repo))
+}
+
 // OptimizedDir returns the path for optimized config storage.
 func (p *Paths) OptimizedDir() string {
 	return filepath.Join(p.ConfigDir, "optimized")
@@ -97,8 +105,20 @@ func (p *Paths) OptimizedMetaFile(owner, repo string) string {
 
 // ClaudeCommandsDir returns the path for Claude Code custom commands.
 func (p *Paths) ClaudeCommandsDir() string {
-	home := os.Getenv("HOME")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
 	return filepath.Join(home, ".claude", "commands")
+}
+
+// ClaudeRulesDir returns the path for Claude Code user-level rules.
+func (p *Paths) ClaudeRulesDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+	return filepath.Join(home, ".claude", "rules")
 }
 
 // ProjectClaudeCommandsDir returns the path for project-level Claude Code commands.
@@ -121,6 +141,7 @@ type ProjectPaths struct {
 	CommandsDir  string // .staghorn/commands/
 	LanguagesDir string // .staghorn/languages/
 	EvalsDir     string // .staghorn/evals/
+	RulesDir     string // .staghorn/rules/
 	ConfigFile   string // .staghorn/config.yaml (optional project config)
 }
 
@@ -135,6 +156,7 @@ func NewProjectPaths(projectRoot string) *ProjectPaths {
 		CommandsDir:  filepath.Join(staghornDir, "commands"),
 		LanguagesDir: filepath.Join(staghornDir, "languages"),
 		EvalsDir:     filepath.Join(staghornDir, "evals"),
+		RulesDir:     filepath.Join(staghornDir, "rules"),
 		ConfigFile:   filepath.Join(staghornDir, "config.yaml"),
 	}
 }
@@ -142,4 +164,14 @@ func NewProjectPaths(projectRoot string) *ProjectPaths {
 // ProjectEvalsDir returns the path for project-specific evals.
 func ProjectEvalsDir(projectRoot string) string {
 	return filepath.Join(projectRoot, ".staghorn", "evals")
+}
+
+// ProjectRulesDir returns the path for project-specific rules.
+func ProjectRulesDir(projectRoot string) string {
+	return filepath.Join(projectRoot, ".staghorn", "rules")
+}
+
+// ProjectClaudeRulesDir returns the path for project-level Claude Code rules.
+func ProjectClaudeRulesDir(projectRoot string) string {
+	return filepath.Join(projectRoot, ".claude", "rules")
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -267,6 +267,151 @@ Team rules only.`
 	assert.True(t, asserter.ContainsText("Team rules only"), "should contain team content")
 }
 
+// TestIntegration_RulesBasicSync tests basic rule sync to Claude directory.
+func TestIntegration_RulesBasicSync(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+
+	// Setup team rule
+	teamRule := `# Security Guidelines
+
+Never commit secrets.`
+
+	err := env.SetupTeamRule(owner, repo, "security.md", teamRule)
+	require.NoError(t, err)
+
+	// Run sync
+	count, err := env.RunSyncRules(owner, repo)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "should sync 1 rule")
+
+	// Read output and verify
+	output, err := env.ReadClaudeRule("security.md")
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "Managed by staghorn", "should have managed header")
+	assert.Contains(t, output, "Source: team", "should have team source")
+	assert.Contains(t, output, "Never commit secrets", "should contain rule content")
+}
+
+// TestIntegration_RulesWithPaths tests rules with path-scoping frontmatter.
+func TestIntegration_RulesWithPaths(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+
+	// Setup rule with paths frontmatter
+	teamRule := `---
+paths:
+  - "src/api/**/*.ts"
+  - "src/routes/**/*.ts"
+---
+# REST API Standards
+
+Use proper HTTP methods.`
+
+	err := env.SetupTeamRule(owner, repo, "api/rest.md", teamRule)
+	require.NoError(t, err)
+
+	count, err := env.RunSyncRules(owner, repo)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	output, err := env.ReadClaudeRule("api/rest.md")
+	require.NoError(t, err)
+
+	// Verify frontmatter is preserved (required for Claude's path-scoping)
+	assert.Contains(t, output, "---", "should have frontmatter delimiters")
+	assert.Contains(t, output, "paths:", "should have paths in frontmatter")
+	assert.Contains(t, output, "src/api/**/*.ts", "should preserve path patterns")
+	assert.Contains(t, output, "Use proper HTTP methods", "should contain rule body")
+}
+
+// TestIntegration_RulesPrecedence tests that personal rules override team rules.
+func TestIntegration_RulesPrecedence(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+
+	// Setup team rule
+	teamRule := `# Security
+
+Team security guidelines.`
+
+	// Setup personal rule with same path (should override)
+	personalRule := `# Security
+
+My personal security preferences.`
+
+	err := env.SetupTeamRule(owner, repo, "security.md", teamRule)
+	require.NoError(t, err)
+
+	err = env.SetupPersonalRule("security.md", personalRule)
+	require.NoError(t, err)
+
+	count, err := env.RunSyncRules(owner, repo)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "should have 1 unique rule (personal overrides team)")
+
+	output, err := env.ReadClaudeRule("security.md")
+	require.NoError(t, err)
+
+	// Personal should win
+	assert.Contains(t, output, "Source: personal", "should have personal source (higher precedence)")
+	assert.Contains(t, output, "My personal security preferences", "should contain personal content")
+	assert.NotContains(t, output, "Team security guidelines", "should NOT contain team content")
+}
+
+// TestIntegration_RulesSubdirectories tests rules in subdirectories.
+func TestIntegration_RulesSubdirectories(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+
+	// Setup rules in different subdirectories
+	err := env.SetupTeamRule(owner, repo, "security.md", "# Security")
+	require.NoError(t, err)
+
+	err = env.SetupTeamRule(owner, repo, "api/rest.md", "# REST API")
+	require.NoError(t, err)
+
+	err = env.SetupTeamRule(owner, repo, "frontend/react.md", "# React Guidelines")
+	require.NoError(t, err)
+
+	count, err := env.RunSyncRules(owner, repo)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count, "should sync 3 rules")
+
+	// Verify each rule exists in correct location
+	_, err = env.ReadClaudeRule("security.md")
+	require.NoError(t, err, "security.md should exist")
+
+	_, err = env.ReadClaudeRule("api/rest.md")
+	require.NoError(t, err, "api/rest.md should exist")
+
+	_, err = env.ReadClaudeRule("frontend/react.md")
+	require.NoError(t, err, "frontend/react.md should exist")
+}
+
+// TestIntegration_RulesEmptyDirs tests sync with no rules.
+func TestIntegration_RulesEmptyDirs(t *testing.T) {
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	owner, repo := "acme", "standards"
+
+	// No rules set up - directories don't exist
+
+	count, err := env.RunSyncRules(owner, repo)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "should sync 0 rules")
+}
+
 // TestIntegration_ProvenanceOrder tests that team content appears before personal.
 func TestIntegration_ProvenanceOrder(t *testing.T) {
 	env := NewTestEnv(t)

--- a/internal/rules/claude.go
+++ b/internal/rules/claude.go
@@ -1,0 +1,34 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConvertToClaude converts a staghorn rule to Claude Code rules format.
+// It preserves the frontmatter (required for path-scoping) and adds a staghorn header.
+func ConvertToClaude(rule *Rule) (string, error) {
+	var sb strings.Builder
+
+	// Preserve original frontmatter if present (required for path-scoping)
+	if len(rule.Frontmatter.Paths) > 0 {
+		sb.WriteString("---\n")
+		yamlBytes, err := yaml.Marshal(rule.Frontmatter)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal frontmatter: %w", err)
+		}
+		sb.Write(yamlBytes)
+		sb.WriteString("---\n\n")
+	}
+
+	// Add staghorn header after frontmatter so it doesn't interfere with Claude's parsing
+	sb.WriteString(fmt.Sprintf("<!-- Managed by staghorn | Source: %s | Do not edit directly -->\n\n", rule.Source.Label()))
+
+	// Add the body
+	sb.WriteString(rule.Body)
+	sb.WriteString("\n")
+
+	return sb.String(), nil
+}

--- a/internal/rules/claude_test.go
+++ b/internal/rules/claude_test.go
@@ -1,0 +1,160 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConvertToClaude(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    *Rule
+		wantHas []string
+		wantNot []string
+	}{
+		{
+			name: "rule with paths frontmatter",
+			rule: &Rule{
+				Frontmatter: Frontmatter{
+					Paths: []string{"src/api/**/*.ts", "src/routes/**/*.ts"},
+				},
+				Name:   "rest",
+				Body:   "# REST API\n\nUse proper methods.",
+				Source: SourceTeam,
+			},
+			wantHas: []string{
+				"---\n",
+				"paths:",
+				"src/api/**/*.ts",
+				"src/routes/**/*.ts",
+				"<!-- Managed by staghorn | Source: team | Do not edit directly -->",
+				"# REST API",
+				"Use proper methods.",
+			},
+		},
+		{
+			name: "rule without paths",
+			rule: &Rule{
+				Name:   "security",
+				Body:   "# Security\n\nValidate input.",
+				Source: SourcePersonal,
+			},
+			wantHas: []string{
+				"<!-- Managed by staghorn | Source: personal | Do not edit directly -->",
+				"# Security",
+				"Validate input.",
+			},
+			wantNot: []string{
+				"---\n",
+				"paths:",
+			},
+		},
+		{
+			name: "rule from project source",
+			rule: &Rule{
+				Frontmatter: Frontmatter{
+					Paths: []string{"src/**/*.go"},
+				},
+				Name:   "go",
+				Body:   "# Go Rules",
+				Source: SourceProject,
+			},
+			wantHas: []string{
+				"Source: project",
+				"src/**/*.go",
+			},
+		},
+		{
+			name: "rule from starter source",
+			rule: &Rule{
+				Name:   "testing",
+				Body:   "# Testing",
+				Source: SourceStarter,
+			},
+			wantHas: []string{
+				"Source: starter",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertToClaude(tt.rule)
+			if err != nil {
+				t.Fatalf("ConvertToClaude failed: %v", err)
+			}
+
+			for _, want := range tt.wantHas {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q\nGot:\n%s", want, got)
+				}
+			}
+
+			for _, notWant := range tt.wantNot {
+				if strings.Contains(got, notWant) {
+					t.Errorf("output should not contain %q\nGot:\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertToClaude_FrontmatterFirst(t *testing.T) {
+	rule := &Rule{
+		Frontmatter: Frontmatter{
+			Paths: []string{"src/**/*.ts"},
+		},
+		Name:   "test",
+		Body:   "# Test",
+		Source: SourceTeam,
+	}
+
+	got, err := ConvertToClaude(rule)
+	if err != nil {
+		t.Fatalf("ConvertToClaude failed: %v", err)
+	}
+
+	// Frontmatter should come before the managed header
+	fmIdx := strings.Index(got, "---\n")
+	headerIdx := strings.Index(got, "<!-- Managed by staghorn")
+
+	if fmIdx == -1 {
+		t.Fatal("missing frontmatter")
+	}
+	if headerIdx == -1 {
+		t.Fatal("missing managed header")
+	}
+	if fmIdx > headerIdx {
+		t.Error("frontmatter should come before managed header")
+	}
+}
+
+func TestConvertToClaude_BodyLast(t *testing.T) {
+	rule := &Rule{
+		Frontmatter: Frontmatter{
+			Paths: []string{"src/**/*.ts"},
+		},
+		Name:   "test",
+		Body:   "# Test Content Here",
+		Source: SourceTeam,
+	}
+
+	got, err := ConvertToClaude(rule)
+	if err != nil {
+		t.Fatalf("ConvertToClaude failed: %v", err)
+	}
+
+	// Body should come after the managed header
+	headerIdx := strings.Index(got, "<!-- Managed by staghorn")
+	bodyIdx := strings.Index(got, "# Test Content Here")
+
+	if headerIdx == -1 {
+		t.Fatal("missing managed header")
+	}
+	if bodyIdx == -1 {
+		t.Fatal("missing body")
+	}
+	if bodyIdx < headerIdx {
+		t.Error("body should come after managed header")
+	}
+}

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -1,0 +1,121 @@
+package rules
+
+import "sort"
+
+// Registry manages rules from multiple sources with precedence handling.
+// Precedence (highest to lowest): project > personal > team
+// Key is the relative path (e.g., "api/rest.md", "security.md")
+type Registry struct {
+	rules    map[string]*Rule // relPath -> rule (highest precedence wins)
+	bySource map[Source][]*Rule
+}
+
+// NewRegistry creates an empty rule registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		rules:    make(map[string]*Rule),
+		bySource: make(map[Source][]*Rule),
+	}
+}
+
+// Add adds a rule to the registry.
+// Higher precedence sources (project > personal > team) override lower ones.
+func (r *Registry) Add(rule *Rule) {
+	existing, exists := r.rules[rule.RelPath]
+
+	// Determine if new rule should override existing
+	shouldOverride := !exists || sourcePrecedence(rule.Source) > sourcePrecedence(existing.Source)
+
+	if shouldOverride {
+		r.rules[rule.RelPath] = rule
+	}
+
+	// Always track by source
+	r.bySource[rule.Source] = append(r.bySource[rule.Source], rule)
+}
+
+// sourcePrecedence returns the precedence level for a source.
+// Higher values = higher precedence (wins in conflicts).
+func sourcePrecedence(s Source) int {
+	switch s {
+	case SourceTeam:
+		return 1
+	case SourceStarter:
+		return 1 // Same as team
+	case SourcePersonal:
+		return 2
+	case SourceProject:
+		return 3
+	default:
+		return 0
+	}
+}
+
+// All returns all unique rules (highest precedence version of each),
+// sorted by relative path for deterministic ordering.
+func (r *Registry) All() []*Rule {
+	result := make([]*Rule, 0, len(r.rules))
+	for _, rule := range r.rules {
+		result = append(result, rule)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].RelPath < result[j].RelPath
+	})
+	return result
+}
+
+// Get returns a rule by its relative path.
+func (r *Registry) Get(relPath string) *Rule {
+	return r.rules[relPath]
+}
+
+// BySource returns all rules from a specific source.
+func (r *Registry) BySource(source Source) []*Rule {
+	return r.bySource[source]
+}
+
+// Count returns the number of unique rules.
+func (r *Registry) Count() int {
+	return len(r.rules)
+}
+
+// LoadRegistry creates a registry by loading rules from all sources.
+// Empty string for any directory means that source is not available.
+func LoadRegistry(teamDir, personalDir, projectDir string) (*Registry, error) {
+	registry := NewRegistry()
+
+	// Load team rules (lowest precedence)
+	if teamDir != "" {
+		teamRules, err := LoadFromDirectory(teamDir, SourceTeam)
+		if err != nil {
+			return nil, err
+		}
+		for _, rule := range teamRules {
+			registry.Add(rule)
+		}
+	}
+
+	// Load personal rules (middle precedence)
+	if personalDir != "" {
+		personalRules, err := LoadFromDirectory(personalDir, SourcePersonal)
+		if err != nil {
+			return nil, err
+		}
+		for _, rule := range personalRules {
+			registry.Add(rule)
+		}
+	}
+
+	// Load project rules (highest precedence)
+	if projectDir != "" {
+		projectRules, err := LoadFromDirectory(projectDir, SourceProject)
+		if err != nil {
+			return nil, err
+		}
+		for _, rule := range projectRules {
+			registry.Add(rule)
+		}
+	}
+
+	return registry, nil
+}

--- a/internal/rules/registry_test.go
+++ b/internal/rules/registry_test.go
@@ -1,0 +1,254 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistry_Add(t *testing.T) {
+	r := NewRegistry()
+
+	// Add team rule
+	teamRule := &Rule{
+		Name:    "security",
+		RelPath: "security.md",
+		Source:  SourceTeam,
+		Body:    "Team security rules",
+	}
+	r.Add(teamRule)
+
+	// Verify it was added
+	if got := r.Get("security.md"); got != teamRule {
+		t.Error("team rule not added")
+	}
+
+	// Add personal rule with same relPath - should override
+	personalRule := &Rule{
+		Name:    "security",
+		RelPath: "security.md",
+		Source:  SourcePersonal,
+		Body:    "Personal security rules",
+	}
+	r.Add(personalRule)
+
+	// Verify personal rule overrides team
+	if got := r.Get("security.md"); got != personalRule {
+		t.Error("personal rule should override team rule")
+	}
+
+	// Add project rule - should override personal
+	projectRule := &Rule{
+		Name:    "security",
+		RelPath: "security.md",
+		Source:  SourceProject,
+		Body:    "Project security rules",
+	}
+	r.Add(projectRule)
+
+	if got := r.Get("security.md"); got != projectRule {
+		t.Error("project rule should override personal rule")
+	}
+
+	// Try to add team rule again - should NOT override project
+	anotherTeamRule := &Rule{
+		Name:    "security",
+		RelPath: "security.md",
+		Source:  SourceTeam,
+		Body:    "Another team rule",
+	}
+	r.Add(anotherTeamRule)
+
+	if got := r.Get("security.md"); got != projectRule {
+		t.Error("team rule should not override project rule")
+	}
+}
+
+func TestRegistry_All(t *testing.T) {
+	r := NewRegistry()
+
+	r.Add(&Rule{RelPath: "a.md", Source: SourceTeam})
+	r.Add(&Rule{RelPath: "b.md", Source: SourcePersonal})
+	r.Add(&Rule{RelPath: "c.md", Source: SourceProject})
+	// Override a.md with personal
+	r.Add(&Rule{RelPath: "a.md", Source: SourcePersonal})
+
+	all := r.All()
+	if len(all) != 3 {
+		t.Errorf("All() returned %d rules, want 3", len(all))
+	}
+}
+
+func TestRegistry_BySource(t *testing.T) {
+	r := NewRegistry()
+
+	r.Add(&Rule{RelPath: "a.md", Source: SourceTeam})
+	r.Add(&Rule{RelPath: "b.md", Source: SourceTeam})
+	r.Add(&Rule{RelPath: "c.md", Source: SourcePersonal})
+
+	teamRules := r.BySource(SourceTeam)
+	if len(teamRules) != 2 {
+		t.Errorf("BySource(team) returned %d rules, want 2", len(teamRules))
+	}
+
+	personalRules := r.BySource(SourcePersonal)
+	if len(personalRules) != 1 {
+		t.Errorf("BySource(personal) returned %d rules, want 1", len(personalRules))
+	}
+
+	projectRules := r.BySource(SourceProject)
+	if len(projectRules) != 0 {
+		t.Errorf("BySource(project) returned %d rules, want 0", len(projectRules))
+	}
+}
+
+func TestRegistry_Count(t *testing.T) {
+	r := NewRegistry()
+
+	if r.Count() != 0 {
+		t.Error("empty registry should have count 0")
+	}
+
+	r.Add(&Rule{RelPath: "a.md", Source: SourceTeam})
+	r.Add(&Rule{RelPath: "b.md", Source: SourceTeam})
+	// Override a.md
+	r.Add(&Rule{RelPath: "a.md", Source: SourcePersonal})
+
+	if r.Count() != 2 {
+		t.Errorf("Count() = %d, want 2 (unique relPaths)", r.Count())
+	}
+}
+
+func TestLoadRegistry(t *testing.T) {
+	// Create temp directories
+	tmpDir := t.TempDir()
+	teamDir := filepath.Join(tmpDir, "team")
+	personalDir := filepath.Join(tmpDir, "personal")
+	projectDir := filepath.Join(tmpDir, "project")
+
+	for _, dir := range []string{teamDir, personalDir, projectDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create team rule
+	if err := os.WriteFile(filepath.Join(teamDir, "security.md"), []byte("# Team Security"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create personal rule (overrides team)
+	if err := os.WriteFile(filepath.Join(personalDir, "security.md"), []byte("# Personal Security"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create project-only rule
+	if err := os.WriteFile(filepath.Join(projectDir, "project-only.md"), []byte("# Project Only"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	registry, err := LoadRegistry(teamDir, personalDir, projectDir)
+	if err != nil {
+		t.Fatalf("LoadRegistry failed: %v", err)
+	}
+
+	// Should have 2 unique rules
+	if registry.Count() != 2 {
+		t.Errorf("Count() = %d, want 2", registry.Count())
+	}
+
+	// security.md should be from personal (overrides team)
+	securityRule := registry.Get("security.md")
+	if securityRule == nil {
+		t.Fatal("missing security.md rule")
+	}
+	if securityRule.Source != SourcePersonal {
+		t.Errorf("security.md source = %q, want %q", securityRule.Source, SourcePersonal)
+	}
+
+	// project-only.md should exist
+	projectRule := registry.Get("project-only.md")
+	if projectRule == nil {
+		t.Fatal("missing project-only.md rule")
+	}
+	if projectRule.Source != SourceProject {
+		t.Errorf("project-only.md source = %q, want %q", projectRule.Source, SourceProject)
+	}
+}
+
+func TestLoadRegistry_EmptyDirs(t *testing.T) {
+	registry, err := LoadRegistry("", "", "")
+	if err != nil {
+		t.Fatalf("LoadRegistry with empty dirs failed: %v", err)
+	}
+	if registry.Count() != 0 {
+		t.Errorf("Count() = %d, want 0", registry.Count())
+	}
+}
+
+func TestLoadRegistry_SubdirectoryConflict(t *testing.T) {
+	// Test that subdirectory rules are also properly overridden
+	tmpDir := t.TempDir()
+	teamDir := filepath.Join(tmpDir, "team", "api")
+	personalDir := filepath.Join(tmpDir, "personal", "api")
+
+	for _, dir := range []string{teamDir, personalDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create team api/rest.md
+	if err := os.WriteFile(filepath.Join(teamDir, "rest.md"), []byte("# Team REST"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create personal api/rest.md (overrides team)
+	if err := os.WriteFile(filepath.Join(personalDir, "rest.md"), []byte("# Personal REST"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	registry, err := LoadRegistry(
+		filepath.Join(tmpDir, "team"),
+		filepath.Join(tmpDir, "personal"),
+		"",
+	)
+	if err != nil {
+		t.Fatalf("LoadRegistry failed: %v", err)
+	}
+
+	// Should have 1 unique rule
+	if registry.Count() != 1 {
+		t.Errorf("Count() = %d, want 1", registry.Count())
+	}
+
+	// api/rest.md should be from personal
+	restRule := registry.Get("api/rest.md")
+	if restRule == nil {
+		t.Fatal("missing api/rest.md rule")
+	}
+	if restRule.Source != SourcePersonal {
+		t.Errorf("api/rest.md source = %q, want %q", restRule.Source, SourcePersonal)
+	}
+}
+
+func TestSourcePrecedence(t *testing.T) {
+	// Verify precedence order: project > personal > team = starter
+	tests := []struct {
+		source Source
+		want   int
+	}{
+		{SourceTeam, 1},
+		{SourceStarter, 1},
+		{SourcePersonal, 2},
+		{SourceProject, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.source), func(t *testing.T) {
+			if got := sourcePrecedence(tt.source); got != tt.want {
+				t.Errorf("sourcePrecedence(%q) = %d, want %d", tt.source, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -1,0 +1,186 @@
+// Package rules handles staghorn rule parsing, registry, and rendering.
+package rules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ParseErrors collects multiple parse errors when loading rules from a directory.
+// Individual parse failures don't prevent other rules from loading.
+type ParseErrors struct {
+	Errors []error
+}
+
+func (e *ParseErrors) Error() string {
+	if len(e.Errors) == 1 {
+		return e.Errors[0].Error()
+	}
+	return fmt.Sprintf("%d rules failed to parse", len(e.Errors))
+}
+
+// Source indicates where a rule came from.
+type Source string
+
+const (
+	SourceTeam     Source = "team"
+	SourcePersonal Source = "personal"
+	SourceProject  Source = "project"
+	SourceStarter  Source = "starter"
+)
+
+// Label returns a human-readable label for the source.
+func (s Source) Label() string {
+	switch s {
+	case SourceTeam:
+		return "team"
+	case SourcePersonal:
+		return "personal"
+	case SourceProject:
+		return "project"
+	case SourceStarter:
+		return "starter"
+	default:
+		return string(s)
+	}
+}
+
+// Frontmatter contains the YAML frontmatter of a rule.
+type Frontmatter struct {
+	Paths []string `yaml:"paths,omitempty"` // Glob patterns for path-scoping
+}
+
+// Rule represents a staghorn rule file.
+type Rule struct {
+	Frontmatter        // Embedded; access paths via rule.Frontmatter.Paths or rule.Paths
+	Name        string // Derived from filename (e.g., "security" from "security.md")
+	Body        string // Markdown content after frontmatter
+	Source      Source // Where this rule came from
+	FilePath    string // Absolute path to the rule file
+	RelPath     string // Relative path within rules/ (preserves subdirs, e.g., "api/rest.md")
+}
+
+// Parse parses a rule from markdown content.
+func Parse(content string, source Source, filePath, relPath string) (*Rule, error) {
+	lines := strings.Split(content, "\n")
+
+	var fm Frontmatter
+	var body string
+	var endIdx int
+
+	// Check for frontmatter delimiter
+	if len(lines) > 0 && strings.TrimSpace(lines[0]) == "---" {
+		// Find end of frontmatter
+		endIdx = -1
+		for i := 1; i < len(lines); i++ {
+			if strings.TrimSpace(lines[i]) == "---" {
+				endIdx = i
+				break
+			}
+		}
+
+		if endIdx == -1 {
+			return nil, fmt.Errorf("unterminated frontmatter (missing closing ---)")
+		}
+
+		// Parse frontmatter
+		frontmatterYAML := strings.Join(lines[1:endIdx], "\n")
+		if err := yaml.Unmarshal([]byte(frontmatterYAML), &fm); err != nil {
+			return nil, fmt.Errorf("invalid frontmatter YAML: %w", err)
+		}
+
+		// Extract body (everything after frontmatter)
+		if endIdx+1 < len(lines) {
+			body = strings.TrimSpace(strings.Join(lines[endIdx+1:], "\n"))
+		}
+	} else {
+		// No frontmatter, entire content is the body
+		body = strings.TrimSpace(content)
+	}
+
+	// Derive name from filename
+	name := strings.TrimSuffix(filepath.Base(relPath), ".md")
+
+	return &Rule{
+		Frontmatter: fm,
+		Name:        name,
+		Body:        body,
+		Source:      source,
+		FilePath:    filePath,
+		RelPath:     relPath,
+	}, nil
+}
+
+// ParseFile parses a rule from a file.
+func ParseFile(path string, source Source, relPath string) (*Rule, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read rule file: %w", err)
+	}
+	return Parse(string(content), source, path, relPath)
+}
+
+// LoadFromDirectory loads all rules from a directory (recursive).
+// Parse errors for individual files are collected in the returned ParseErrors slice
+// but do not prevent other rules from loading.
+func LoadFromDirectory(dir string, source Source) ([]*Rule, error) {
+	var rules []*Rule
+	var parseErrors []error
+
+	// Check if directory exists
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil, nil // Directory doesn't exist, return empty
+	}
+
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if d.IsDir() {
+			return nil
+		}
+
+		// Only process .md files
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+
+		// Calculate relative path from the rules directory
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path: %w", err)
+		}
+
+		rule, err := ParseFile(path, source, relPath)
+		if err != nil {
+			// Collect parse error but continue loading other rules
+			parseErrors = append(parseErrors, fmt.Errorf("failed to parse %s: %w", path, err))
+			return nil
+		}
+
+		rules = append(rules, rule)
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to read rules directory: %w", err)
+	}
+
+	// Return first parse error if any occurred (caller can check for more via type assertion)
+	if len(parseErrors) > 0 {
+		return rules, &ParseErrors{Errors: parseErrors}
+	}
+
+	return rules, nil
+}
+
+// HasPathScope returns true if the rule has path-specific scope.
+func (r *Rule) HasPathScope() bool {
+	return len(r.Frontmatter.Paths) > 0
+}

--- a/internal/rules/rule_test.go
+++ b/internal/rules/rule_test.go
@@ -1,0 +1,275 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		source      Source
+		filePath    string
+		relPath     string
+		wantName    string
+		wantPaths   []string
+		wantBody    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "rule with frontmatter and paths",
+			content: `---
+paths:
+  - "src/api/**/*.ts"
+  - "src/routes/**/*.ts"
+---
+# API Rules
+
+Use proper status codes.`,
+			source:    SourceTeam,
+			filePath:  "/team/rules/api.md",
+			relPath:   "api.md",
+			wantName:  "api",
+			wantPaths: []string{"src/api/**/*.ts", "src/routes/**/*.ts"},
+			wantBody:  "# API Rules\n\nUse proper status codes.",
+		},
+		{
+			name: "rule without frontmatter",
+			content: `# Security Guidelines
+
+Never commit secrets.`,
+			source:   SourcePersonal,
+			filePath: "/personal/rules/security.md",
+			relPath:  "security.md",
+			wantName: "security",
+			wantBody: "# Security Guidelines\n\nNever commit secrets.",
+		},
+		{
+			name: "rule with empty frontmatter",
+			content: `---
+---
+# Testing
+
+Write tests.`,
+			source:   SourceProject,
+			filePath: "/project/rules/testing.md",
+			relPath:  "testing.md",
+			wantName: "testing",
+			wantBody: "# Testing\n\nWrite tests.",
+		},
+		{
+			name: "rule in subdirectory",
+			content: `---
+paths:
+  - "src/components/**/*.tsx"
+---
+# React Rules`,
+			source:    SourceTeam,
+			filePath:  "/team/rules/frontend/react.md",
+			relPath:   "frontend/react.md",
+			wantName:  "react",
+			wantPaths: []string{"src/components/**/*.tsx"},
+			wantBody:  "# React Rules",
+		},
+		{
+			name: "unterminated frontmatter",
+			content: `---
+paths:
+  - "src/**/*.ts"
+# Missing closing ---`,
+			source:      SourceTeam,
+			filePath:    "/team/rules/bad.md",
+			relPath:     "bad.md",
+			wantErr:     true,
+			errContains: "unterminated frontmatter",
+		},
+		{
+			name: "invalid yaml frontmatter",
+			content: `---
+paths: [invalid yaml
+---
+# Content`,
+			source:      SourceTeam,
+			filePath:    "/team/rules/bad.md",
+			relPath:     "bad.md",
+			wantErr:     true,
+			errContains: "invalid frontmatter YAML",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule, err := Parse(tt.content, tt.source, tt.filePath, tt.relPath)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errContains)
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if rule.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", rule.Name, tt.wantName)
+			}
+
+			if rule.Source != tt.source {
+				t.Errorf("Source = %q, want %q", rule.Source, tt.source)
+			}
+
+			if rule.FilePath != tt.filePath {
+				t.Errorf("FilePath = %q, want %q", rule.FilePath, tt.filePath)
+			}
+
+			if rule.RelPath != tt.relPath {
+				t.Errorf("RelPath = %q, want %q", rule.RelPath, tt.relPath)
+			}
+
+			if rule.Body != tt.wantBody {
+				t.Errorf("Body = %q, want %q", rule.Body, tt.wantBody)
+			}
+
+			if len(rule.Paths) != len(tt.wantPaths) {
+				t.Errorf("Paths length = %d, want %d", len(rule.Paths), len(tt.wantPaths))
+			} else {
+				for i, path := range rule.Paths {
+					if path != tt.wantPaths[i] {
+						t.Errorf("Paths[%d] = %q, want %q", i, path, tt.wantPaths[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestLoadFromDirectory(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+
+	// Create rules directory with subdirectories
+	rulesDir := filepath.Join(tmpDir, "rules")
+	apiDir := filepath.Join(rulesDir, "api")
+	if err := os.MkdirAll(apiDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rule files
+	files := map[string]string{
+		"security.md": `# Security
+
+Validate input.`,
+		"api/rest.md": `---
+paths:
+  - "src/api/**/*.ts"
+---
+# REST API
+
+Use proper methods.`,
+	}
+
+	for name, content := range files {
+		path := filepath.Join(rulesDir, name)
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Also create a non-md file that should be ignored
+	if err := os.WriteFile(filepath.Join(rulesDir, "readme.txt"), []byte("ignore me"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load rules
+	rules, err := LoadFromDirectory(rulesDir, SourceTeam)
+	if err != nil {
+		t.Fatalf("LoadFromDirectory failed: %v", err)
+	}
+
+	if len(rules) != 2 {
+		t.Fatalf("got %d rules, want 2", len(rules))
+	}
+
+	// Check that we got both rules with correct relative paths
+	ruleMap := make(map[string]*Rule)
+	for _, r := range rules {
+		ruleMap[r.RelPath] = r
+	}
+
+	if _, ok := ruleMap["security.md"]; !ok {
+		t.Error("missing security.md rule")
+	}
+
+	if r, ok := ruleMap["api/rest.md"]; !ok {
+		t.Error("missing api/rest.md rule")
+	} else {
+		if r.Name != "rest" {
+			t.Errorf("api/rest.md Name = %q, want %q", r.Name, "rest")
+		}
+		if len(r.Paths) != 1 || r.Paths[0] != "src/api/**/*.ts" {
+			t.Errorf("api/rest.md Paths = %v, want [src/api/**/*.ts]", r.Paths)
+		}
+	}
+}
+
+func TestLoadFromDirectory_NonExistent(t *testing.T) {
+	rules, err := LoadFromDirectory("/nonexistent/path", SourceTeam)
+	if err != nil {
+		t.Fatalf("expected nil error for nonexistent directory, got: %v", err)
+	}
+	if rules != nil {
+		t.Errorf("expected nil rules for nonexistent directory, got: %v", rules)
+	}
+}
+
+func TestHasPathScope(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		want  bool
+	}{
+		{"no paths", nil, false},
+		{"empty paths", []string{}, false},
+		{"has paths", []string{"src/**/*.ts"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Rule{Frontmatter: Frontmatter{Paths: tt.paths}}
+			if got := r.HasPathScope(); got != tt.want {
+				t.Errorf("HasPathScope() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSourceLabel(t *testing.T) {
+	tests := []struct {
+		source Source
+		want   string
+	}{
+		{SourceTeam, "team"},
+		{SourcePersonal, "personal"},
+		{SourceProject, "project"},
+		{SourceStarter, "starter"},
+		{Source("unknown"), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.source), func(t *testing.T) {
+			if got := tt.source.Label(); got != tt.want {
+				t.Errorf("Label() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/starter/rules.go
+++ b/internal/starter/rules.go
@@ -1,0 +1,156 @@
+package starter
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/HartBrook/staghorn/internal/rules"
+)
+
+//go:embed rules/*.md rules/**/*.md
+var rulesFS embed.FS
+
+// RuleNames returns the list of available starter rule names (relative paths).
+func RuleNames() []string {
+	var names []string
+	_ = fs.WalkDir(rulesFS, "rules", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".md") {
+			// Get relative path from rules/
+			relPath := strings.TrimPrefix(path, "rules/")
+			names = append(names, relPath)
+		}
+		return nil
+	})
+	return names
+}
+
+// BootstrapRules copies starter rules to the target directory.
+// It skips files that already exist. Returns the number of rules copied.
+func BootstrapRules(targetDir string) (int, error) {
+	count, _, err := BootstrapRulesWithSkip(targetDir, nil)
+	return count, err
+}
+
+// BootstrapRulesWithSkip copies starter rules to the target directory,
+// skipping rules in the skip list. Returns the count and names of installed rules.
+func BootstrapRulesWithSkip(targetDir string, skip []string) (int, []string, error) {
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return 0, nil, fmt.Errorf("failed to create rules directory: %w", err)
+	}
+
+	// Build skip set
+	skipSet := make(map[string]bool)
+	for _, name := range skip {
+		skipSet[name] = true
+	}
+
+	copied := 0
+	var installed []string
+
+	err := fs.WalkDir(rulesFS, "rules", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+
+		// Get relative path from rules/
+		relPath := strings.TrimPrefix(path, "rules/")
+
+		// Skip if in skip list
+		if skipSet[relPath] {
+			return nil
+		}
+
+		targetPath := filepath.Join(targetDir, relPath)
+
+		// Skip if file already exists
+		if _, err := os.Stat(targetPath); err == nil {
+			return nil
+		}
+
+		content, err := rulesFS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", path, err)
+		}
+
+		// Ensure parent directory exists
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			return fmt.Errorf("failed to create directory for %s: %w", relPath, err)
+		}
+
+		if err := os.WriteFile(targetPath, content, 0644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", relPath, err)
+		}
+
+		copied++
+		installed = append(installed, relPath)
+		return nil
+	})
+
+	if err != nil {
+		return copied, installed, err
+	}
+
+	return copied, installed, nil
+}
+
+// GetRule returns the content of a starter rule by relative path.
+func GetRule(relPath string) ([]byte, error) {
+	return rulesFS.ReadFile(filepath.Join("rules", relPath))
+}
+
+// ListRules returns all embedded rule files.
+func ListRules() ([]fs.DirEntry, error) {
+	return rulesFS.ReadDir("rules")
+}
+
+// LoadStarterRules loads and parses all embedded starter rules.
+func LoadStarterRules() ([]*rules.Rule, error) {
+	var result []*rules.Rule
+
+	err := fs.WalkDir(rulesFS, "rules", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+
+		content, err := rulesFS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", path, err)
+		}
+
+		// Get relative path from rules/
+		relPath := strings.TrimPrefix(path, "rules/")
+
+		rule, err := rules.Parse(string(content), rules.SourceStarter, "", relPath)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s: %w", path, err)
+		}
+
+		result = append(result, rule)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/internal/starter/rules/api/rest.md
+++ b/internal/starter/rules/api/rest.md
@@ -1,0 +1,54 @@
+---
+paths:
+  - "src/api/**/*.ts"
+  - "src/api/**/*.js"
+  - "src/routes/**/*.ts"
+  - "src/routes/**/*.js"
+  - "api/**/*.py"
+  - "app/api/**/*.py"
+  - "internal/api/**/*.go"
+  - "pkg/api/**/*.go"
+---
+# REST API Standards
+
+## HTTP Methods
+
+- Use GET for retrieving resources (idempotent, cacheable)
+- Use POST for creating new resources
+- Use PUT for full resource replacement
+- Use PATCH for partial updates
+- Use DELETE for removing resources
+
+## Status Codes
+
+- 2xx for successful operations (200 OK, 201 Created, 204 No Content)
+- 4xx for client errors (400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found, 422 Unprocessable Entity)
+- 5xx for server errors (500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable)
+
+## Request/Response
+
+- Validate all request input before processing
+- Use consistent error response format with error codes and messages
+- Include pagination for list endpoints (limit, offset or cursor-based)
+- Version APIs in the URL path (/v1/, /v2/) or via Accept headers
+- Use JSON for request and response bodies
+
+## Error Responses
+
+Return errors in a consistent format:
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid request parameters",
+    "details": [...]
+  }
+}
+```
+
+## Documentation
+
+- Document endpoints with OpenAPI/Swagger specifications
+- Include request/response examples for each endpoint
+- Document authentication requirements
+- List all possible error responses with their codes

--- a/internal/starter/rules/error-handling.md
+++ b/internal/starter/rules/error-handling.md
@@ -1,0 +1,22 @@
+# Error Handling
+
+## Error Design
+
+- Handle errors explicitly; never silently ignore them
+- Include context in error messages: what failed and why
+- Create domain-specific error types for errors callers need to handle differently
+- Let errors propagate unless you can meaningfully handle them at that level
+
+## Error Messages
+
+- Write error messages for the person who will read them
+- Include relevant context (IDs, values, state) to aid debugging
+- Avoid exposing sensitive information in error messages
+- Use consistent error message formatting across the codebase
+
+## Error Recovery
+
+- Fail fast; detect and report errors as early as possible
+- Clean up resources properly when errors occur
+- Consider whether operations should be retried
+- Log errors with appropriate severity levels

--- a/internal/starter/rules/frontend/react.md
+++ b/internal/starter/rules/frontend/react.md
@@ -1,0 +1,49 @@
+---
+paths:
+  - "src/components/**/*.tsx"
+  - "src/components/**/*.jsx"
+  - "src/pages/**/*.tsx"
+  - "src/pages/**/*.jsx"
+  - "app/**/*.tsx"
+  - "app/**/*.jsx"
+---
+# React Guidelines
+
+## Component Design
+
+- Use functional components with hooks
+- Keep components small and focused (under 100 lines)
+- Extract reusable logic into custom hooks
+- Prefer composition over inheritance
+- Use TypeScript for type safety
+
+## Props and State
+
+- Define explicit prop types with TypeScript interfaces
+- Keep state as local as possible
+- Lift state up only when necessary for sharing
+- Use context sparingly for truly global state
+- Consider state management libraries for complex state
+
+## Performance
+
+- Memoize expensive calculations with useMemo
+- Memoize callbacks passed to children with useCallback
+- Use React.memo for components that render often with same props
+- Avoid inline object/array creation in render
+- Lazy load components and routes when appropriate
+
+## Accessibility
+
+- Use semantic HTML elements
+- Include proper ARIA attributes when needed
+- Ensure keyboard navigation works
+- Maintain sufficient color contrast
+- Test with screen readers
+
+## Testing
+
+- Test component behavior, not implementation
+- Use React Testing Library for component tests
+- Test user interactions and accessibility
+- Colocate tests with components

--- a/internal/starter/rules/security.md
+++ b/internal/starter/rules/security.md
@@ -1,0 +1,31 @@
+# Security Guidelines
+
+## Secrets and Credentials
+
+- Never commit secrets, API keys, or credentials to version control
+- Use environment variables or secret managers for sensitive configuration
+- Add secret patterns to `.gitignore` (e.g., `.env`, `*.key`, `credentials.json`)
+- Rotate credentials regularly and after any potential exposure
+
+## Input Validation
+
+- Validate and sanitize all external input at system boundaries
+- Use parameterized queries for database access to prevent SQL injection
+- Escape output appropriately to prevent XSS attacks
+- Validate file paths to prevent path traversal attacks
+- Implement rate limiting for public endpoints
+
+## Authentication and Authorization
+
+- Apply the principle of least privilege
+- Validate authentication tokens on every request
+- Use secure session management practices
+- Implement proper CORS policies
+- Log security-relevant events for audit trails
+
+## Dependencies
+
+- Keep dependencies updated to patch known vulnerabilities
+- Use lock files to ensure reproducible builds
+- Review dependency changes before updating
+- Use automated vulnerability scanning in CI/CD

--- a/internal/starter/rules/testing.md
+++ b/internal/starter/rules/testing.md
@@ -1,0 +1,31 @@
+# Testing Standards
+
+## Test Coverage
+
+- Write tests for new functionality and bug fixes
+- Test behavior, not implementation details
+- Cover error paths and edge cases, not just happy paths
+- Aim for meaningful coverage, not just high percentages
+
+## Test Quality
+
+- Keep tests deterministic; avoid flaky tests that depend on timing or external state
+- Use descriptive test names that explain the scenario and expected outcome
+- Isolate tests; each test should set up its own state
+- Clean up test resources after each test
+- Test one thing per test case
+
+## Test Organization
+
+- Colocate tests with the code they test when possible
+- Group related tests logically using describe/context blocks
+- Use test fixtures for complex setup scenarios
+- Mock external dependencies at system boundaries
+- Use factories or builders for test data creation
+
+## Integration Tests
+
+- Test critical user flows end-to-end
+- Use realistic test data
+- Test against actual dependencies when feasible
+- Include performance benchmarks for critical paths

--- a/internal/starter/rules_test.go
+++ b/internal/starter/rules_test.go
@@ -1,0 +1,212 @@
+package starter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRuleNames(t *testing.T) {
+	names := RuleNames()
+
+	if len(names) == 0 {
+		t.Fatal("RuleNames returned empty list")
+	}
+
+	// Check for expected rules
+	expected := []string{
+		"security.md",
+		"testing.md",
+		"error-handling.md",
+		"api/rest.md",
+		"frontend/react.md",
+	}
+
+	nameSet := make(map[string]bool)
+	for _, name := range names {
+		nameSet[name] = true
+	}
+
+	for _, exp := range expected {
+		if !nameSet[exp] {
+			t.Errorf("missing expected rule: %s", exp)
+		}
+	}
+}
+
+func TestGetRule(t *testing.T) {
+	content, err := GetRule("security.md")
+	if err != nil {
+		t.Fatalf("GetRule failed: %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Error("GetRule returned empty content")
+	}
+
+	if !strings.Contains(string(content), "Security") {
+		t.Error("security.md should contain 'Security'")
+	}
+}
+
+func TestGetRule_Subdirectory(t *testing.T) {
+	content, err := GetRule("api/rest.md")
+	if err != nil {
+		t.Fatalf("GetRule failed: %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Error("GetRule returned empty content")
+	}
+
+	// Should have paths frontmatter
+	if !strings.Contains(string(content), "paths:") {
+		t.Error("api/rest.md should have paths frontmatter")
+	}
+}
+
+func TestGetRule_NotFound(t *testing.T) {
+	_, err := GetRule("nonexistent.md")
+	if err == nil {
+		t.Error("expected error for nonexistent rule")
+	}
+}
+
+func TestBootstrapRules(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	count, err := BootstrapRules(tmpDir)
+	if err != nil {
+		t.Fatalf("BootstrapRules failed: %v", err)
+	}
+
+	if count == 0 {
+		t.Error("BootstrapRules copied 0 rules")
+	}
+
+	// Check that security.md was created
+	securityPath := filepath.Join(tmpDir, "security.md")
+	if _, err := os.Stat(securityPath); os.IsNotExist(err) {
+		t.Error("security.md was not created")
+	}
+
+	// Check that api/rest.md was created (subdirectory)
+	restPath := filepath.Join(tmpDir, "api", "rest.md")
+	if _, err := os.Stat(restPath); os.IsNotExist(err) {
+		t.Error("api/rest.md was not created")
+	}
+}
+
+func TestBootstrapRules_SkipsExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create an existing file
+	existingContent := "# My Custom Security"
+	if err := os.WriteFile(filepath.Join(tmpDir, "security.md"), []byte(existingContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := BootstrapRules(tmpDir)
+	if err != nil {
+		t.Fatalf("BootstrapRules failed: %v", err)
+	}
+
+	// Verify existing file was not overwritten
+	content, err := os.ReadFile(filepath.Join(tmpDir, "security.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(content) != existingContent {
+		t.Error("existing file was overwritten")
+	}
+}
+
+func TestBootstrapRulesWithSkip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	count, installed, err := BootstrapRulesWithSkip(tmpDir, []string{"security.md", "api/rest.md"})
+	if err != nil {
+		t.Fatalf("BootstrapRulesWithSkip failed: %v", err)
+	}
+
+	// Check that skipped rules were not installed
+	for _, name := range installed {
+		if name == "security.md" || name == "api/rest.md" {
+			t.Errorf("skipped rule %s was installed", name)
+		}
+	}
+
+	// Check that security.md was NOT created
+	securityPath := filepath.Join(tmpDir, "security.md")
+	if _, err := os.Stat(securityPath); err == nil {
+		t.Error("security.md should have been skipped")
+	}
+
+	// But other rules should exist
+	if count == 0 {
+		t.Error("no rules were installed")
+	}
+}
+
+func TestLoadStarterRules(t *testing.T) {
+	rules, err := LoadStarterRules()
+	if err != nil {
+		t.Fatalf("LoadStarterRules failed: %v", err)
+	}
+
+	if len(rules) == 0 {
+		t.Fatal("LoadStarterRules returned empty list")
+	}
+
+	// Check that rules are properly parsed
+	ruleMap := make(map[string]bool)
+	for _, r := range rules {
+		ruleMap[r.RelPath] = true
+
+		// All rules should have starter source
+		if r.Source != "starter" {
+			t.Errorf("rule %s has source %q, want 'starter'", r.RelPath, r.Source)
+		}
+	}
+
+	// Check expected rules exist
+	expected := []string{"security.md", "testing.md", "api/rest.md", "frontend/react.md"}
+	for _, exp := range expected {
+		if !ruleMap[exp] {
+			t.Errorf("missing expected rule: %s", exp)
+		}
+	}
+}
+
+func TestLoadStarterRules_PathScoped(t *testing.T) {
+	rules, err := LoadStarterRules()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find api/rest.md - it should have paths
+	var restRule *struct {
+		RelPath string
+		Paths   []string
+	}
+
+	for _, r := range rules {
+		if r.RelPath == "api/rest.md" {
+			restRule = &struct {
+				RelPath string
+				Paths   []string
+			}{r.RelPath, r.Paths}
+			break
+		}
+	}
+
+	if restRule == nil {
+		t.Fatal("api/rest.md not found")
+	}
+
+	if len(restRule.Paths) == 0 {
+		t.Error("api/rest.md should have paths for path-scoping")
+	}
+}


### PR DESCRIPTION
## Summary

- Add path-scoped rules system that syncs to `~/.claude/rules/`
- Rules use YAML frontmatter with `paths:` to scope guidelines to specific file patterns
- Implement precedence model: project > personal > team > starter
- Include 5 starter rules: security, testing, api/rest, frontend/react, error-handling

## Changes

**Core rules package** (`internal/rules/`)
- `rule.go` - Rule parsing with frontmatter support and `ParseErrors` type
- `registry.go` - Precedence-based rule registry with deterministic ordering
- `claude.go` - Convert rules to Claude Code format preserving frontmatter

**Sync integration** (`internal/cli/sync.go`)
- Recursive fetching of rules from team repos
- Sync to `~/.claude/rules/` with collision detection
- Add `--rules-only` flag for isolated rule syncing
- Fix `os.RemoveAll` error handling

**Starter rules** (`internal/starter/rules/`)
- Security guidelines (secrets, input validation, auth)
- Testing standards (coverage, quality, organization)
- REST API standards (HTTP methods, status codes, error responses)
- React guidelines (components, state, performance, accessibility)
- Error handling patterns

**Documentation**
- Add Path-Scoped Rules section to README
- Update repository structure, file locations, CLI flags
- Update example/README.md with rules structure

## Test plan

- [x] Unit tests for rule parsing, registry, and conversion
- [x] Integration tests for sync, precedence, and subdirectories
- [x] All existing tests pass
- [x] Lint checks pass