### PR TITLE
Add verify skill and cut v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Agentic workflow rule** (`agentic-workflow.md`) — a global starter rule covering how Claude should operate, not just what good code looks like: verify before claiming done, plan large changes, scope discipline, match surrounding code, and confirm irreversible actions
 - **`workflow-verification` starter eval** — verifies the config promotes verification, scope discipline, surfacing tangents, and honest reporting (brings starter evals to 26)
+- **`verify` starter skill** — operationalizes "verify before claiming done": discovers the project's own build/test commands, runs them, and reports the actual result honestly instead of asserting success from inspection (brings starter skills to 4)
 
 ## [0.8.0] - 2026-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-08
+
 ### Added
 
 - **Agentic workflow rule** (`agentic-workflow.md`) — a global starter rule covering how Claude should operate, not just what good code looks like: verify before claiming done, plan large changes, scope discipline, match surrounding code, and confirm irreversible actions
@@ -204,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for team, personal, and project configuration layers
 - Automatic CLAUDE.md generation with layered content
 
-[Unreleased]: https://github.com/HartBrook/staghorn/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/HartBrook/staghorn/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/HartBrook/staghorn/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/HartBrook/staghorn/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/HartBrook/staghorn/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/HartBrook/staghorn/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`workflow-verification` starter eval** — verifies the config promotes verification, scope discipline, surfacing tangents, and honest reporting (brings starter evals to 26)
 - **`verify` starter skill** — operationalizes "verify before claiming done": discovers the project's own build/test commands, runs them, and reports the actual result honestly instead of asserting success from inspection (brings starter skills to 4)
 
+### Changed
+
+- **Trimmed the bundled `example/team-repo/`** from a near-production config (27 files) down to one minimal file per type, each ~3-8 lines — demonstrates structure and format without duplicating real content. The full worked example now lives in [staghorn-community](https://github.com/HartBrook/staghorn-community), linked from both READMEs
+
 ## [0.8.0] - 2026-01-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -283,13 +283,14 @@ The source file is `.staghorn/project.md` — both it and `./CLAUDE.md` should b
 
 Skills are parameterized, reusable workflows for Claude Code. Unlike commands (which output a prompt), skills can restrict which tools Claude uses, set a model override, run pre/post hooks, and accept structured arguments with validation. Each skill is a directory with a `SKILL.md` file.
 
-Staghorn includes 3 starter skills:
+Staghorn includes 4 starter skills:
 
 | Skill            | Description                                  | Allowed Tools          |
 | ---------------- | -------------------------------------------- | ---------------------- |
 | `code-review`    | Thorough code review with structured feedback | Read, Grep, Glob       |
 | `security-audit` | Scan for security vulnerabilities            | Read, Grep, Glob       |
 | `test-gen`       | Generate unit tests for existing code        | Read, Grep, Glob       |
+| `verify`         | Verify a change works by running it, not inspecting it | Read, Grep, Glob, Bash |
 
 ```bash
 # List available skills

--- a/internal/starter/skills/verify/SKILL.md
+++ b/internal/starter/skills/verify/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: verify
+description: Verify a change actually works by running it, not by inspecting it
+tags: [workflow, quality]
+allowed-tools: Read Grep Glob Bash
+args:
+  - name: target
+    description: The change or feature to verify
+    default: the most recent change
+  - name: checks
+    description: Which checks to run
+    default: auto
+    options: [auto, build, tests, all]
+---
+
+# Verify
+
+Confirm that **{{target}}** actually works by running it and observing the
+result — not by reading the code and assuming. A change is not done until it
+has been verified.
+
+Checks to run: **{{checks}}**
+
+## How to Verify
+
+1. **Discover the project's own commands.** Don't guess. Look at the files that
+   declare them:
+   - `package.json` scripts (`build`, `test`, `lint`), `Makefile` targets,
+     `pyproject.toml` / `tox.ini`, `go.mod` (`go build ./...`, `go test ./...`),
+     `Cargo.toml`, CI config (`.github/workflows/*`).
+   - Prefer the command the project already uses in CI over an ad-hoc one.
+
+2. **Run the relevant checks** for `{{checks}}`:
+   - `build` — compile or build the project.
+   - `tests` — run the test suite (scope to the affected area when the full
+     suite is slow, but say so).
+   - `all` / `auto` — run build then tests; `auto` skips a step the project
+     doesn't have rather than inventing one.
+
+3. **Observe the actual output.** Read exit codes and the real test/build
+   results. Passing means the command reported success — not that the code
+   looks correct.
+
+4. **If a check fails**, stop and report the failure with the actual output.
+   Do not work around it silently or describe it as a minor issue.
+
+## Reporting
+
+Report only what you observed:
+
+- **What ran** — the exact commands.
+- **Result** — pass or fail, with the real output for any failure.
+- **Not covered** — anything you could not verify (no test exists, couldn't run
+  the app, environment missing), stated plainly.
+
+Never claim a change works without having run something that demonstrates it.
+If verification wasn't possible, say exactly what was and wasn't checked rather
+than implying confidence you don't have.

--- a/internal/starter/skills/verify/SKILL.md
+++ b/internal/starter/skills/verify/SKILL.md
@@ -28,6 +28,9 @@ Checks to run: **{{checks}}**
    - `package.json` scripts (`build`, `test`, `lint`), `Makefile` targets,
      `pyproject.toml` / `tox.ini`, `go.mod` (`go build ./...`, `go test ./...`),
      `Cargo.toml`, CI config (`.github/workflows/*`).
+   - Read the project's docs where build/test steps are written in prose:
+     `README.md`, `CONTRIBUTING.md`, `TESTING.md`, or a `docs/` equivalent.
+     A documented command is authoritative — prefer it over one you infer.
    - Prefer the command the project already uses in CI over an ad-hoc one.
 
 2. **Run the relevant checks** for `{{checks}}`:

--- a/internal/starter/skills_test.go
+++ b/internal/starter/skills_test.go
@@ -14,7 +14,7 @@ func TestSkillNames(t *testing.T) {
 	}
 
 	// Check for expected starter skills
-	expected := []string{"code-review", "security-audit", "test-gen"}
+	expected := []string{"code-review", "security-audit", "test-gen", "verify"}
 	for _, exp := range expected {
 		found := false
 		for _, name := range names {


### PR DESCRIPTION
## Summary

Adds the **`verify` starter skill** and **stamps the v0.9.0 release**, gathering all unreleased starter-content changes since v0.8.0.

### verify skill

The agentic-workflow rule (#25) says *verify before claiming done*. This adds the operational counterpart: a runnable `verify` skill that actually does it. It discovers the project's own build/test commands (package.json scripts, Makefile, `go test ./...`, Cargo, CI config — not guesses), runs them, observes the real output, and reports honestly — pass/fail with actual output, plus what it *couldn't* verify. Unlike the read-only starter skills it includes **Bash** so it can run the checks, and it skips a check the project doesn't have rather than inventing one.

### v0.9.0 release

Minor bump — all changes are new backward-compatible starter content. The `[Unreleased]` entries are moved into a dated `0.9.0` section with updated compare links. Captures:

- **Agentic workflow rule** + **workflow-verification eval** (#25, already merged to main)
- **`verify` starter skill** (this PR)

(#24 was docs-only and isn't a changelog feature entry.)

## Changes

- `internal/starter/skills/verify/SKILL.md` — new skill (args: `target`, `checks`)
- `internal/starter/skills_test.go` — register `verify`
- `README.md` — 3 → 4 starter skills
- `CHANGELOG.md` — verify entry + stamp `0.9.0` (2026-06-08) with compare links

## Testing

- `go build ./...` clean
- `go test ./...` passes
- verify skill validated end-to-end through staghorn's loader (parses via `Parse`, renders via `ConvertToClaude`, Bash in allowed-tools, 2 args)

## Release step (after merge)

Releases fire on a `v*` tag (goreleaser → GitHub release + homebrew tap). Push the tag once merged:

```bash
git checkout main && git pull
git tag v0.9.0 && git push origin v0.9.0
```

## Deferred

The **enforcement layer** (syncing a `settings.json` with hooks/permissions; net-new JSON merge) remains deferred for a separate effort.