### PR TITLE
feat(sync): add --branch flag to sync from a specific branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`stag sync --branch <name>`** — sync the config from a specific branch instead of the repository's default branch. Useful for testing standards changes on a branch before merging. An explicit branch always fetches (bypassing the cache-freshness check, since the cache is keyed by repo, not branch) and is rejected for multi-source configurations.
+
 ## [0.9.0] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -983,6 +983,7 @@ Use `stag info --sources` to generate a config with these annotations visible.
 stag sync --fetch-only     # Fetch without applying
 stag sync --apply-only     # Apply cached config without fetching
 stag sync --force          # Re-fetch even if cache is fresh
+stag sync --branch <name>  # Sync from a specific branch (always fetches)
 stag sync --offline        # Use cached config only (no network)
 stag sync --config-only    # Sync config only, skip commands/languages/rules/skills
 stag sync --commands-only  # Sync commands only

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -33,6 +33,7 @@ type syncOptions struct {
 	fetchOnly     bool
 	applyOnly     bool
 	claudeOnly    bool
+	branch        string
 }
 
 // shouldSyncConfig returns true if base config should be synced.
@@ -106,7 +107,8 @@ This is the main command for keeping your Claude Code config up to date.`,
 		Example: `  staghorn sync
   staghorn sync --force
   staghorn sync --fetch-only
-  staghorn sync --apply-only`,
+  staghorn sync --apply-only
+  staghorn sync --branch my-feature-branch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSync(cmd.Context(), opts)
 		},
@@ -122,8 +124,18 @@ This is the main command for keeping your Claude Code config up to date.`,
 	cmd.Flags().BoolVar(&opts.rulesOnly, "rules-only", false, "Only sync rules, skip config, commands, and languages")
 	cmd.Flags().BoolVar(&opts.skillsOnly, "skills-only", false, "Only sync skills, skip config, commands, languages, and rules")
 	cmd.Flags().BoolVar(&opts.claudeOnly, "claude-only", false, "Only sync commands, rules, and skills to ~/.claude/, skip config apply")
+	cmd.Flags().StringVar(&opts.branch, "branch", "", "Sync from a specific branch instead of the repo's default branch")
 
 	return cmd
+}
+
+// resolveBranch returns the explicit branch override when set, otherwise the
+// repository's default branch.
+func resolveBranch(ctx context.Context, client *github.Client, owner, repo, override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	return client.GetDefaultBranch(ctx, owner, repo)
 }
 
 func runSync(ctx context.Context, opts *syncOptions) error {
@@ -146,6 +158,12 @@ func runSync(ctx context.Context, opts *syncOptions) error {
 	// We need the GitHub client for multi-source, so check after client creation
 	isMultiSource := cfg.Source.IsMultiSource()
 
+	// A branch override targets a single repo, so it can't apply when config is
+	// pulled from multiple sources.
+	if opts.branch != "" && isMultiSource {
+		return fmt.Errorf("--branch is not supported with multi-source configuration")
+	}
+
 	// Apply-only mode: skip fetch, just apply from cache
 	if opts.applyOnly {
 		if !c.Exists(owner, repo) {
@@ -167,8 +185,10 @@ func runSync(ctx context.Context, opts *syncOptions) error {
 		return errors.CacheNotFound(owner + "/" + repo)
 	}
 
-	// Check if we need to sync
-	if !opts.force && c.Exists(owner, repo) {
+	// Check if we need to sync. An explicit --branch always fetches: the cache is
+	// keyed by owner/repo (not branch), so a fresh default-branch cache must not
+	// short-circuit a request for a different branch.
+	if !opts.force && opts.branch == "" && c.Exists(owner, repo) {
 		meta, err := c.GetMetadata(owner, repo)
 		if err == nil && !meta.IsStale(cfg.Cache.TTLDuration()) {
 			printSuccess("Cache is fresh (%s)", meta.Age())
@@ -197,8 +217,8 @@ func runSync(ctx context.Context, opts *syncOptions) error {
 		return runMultiSourceSync(ctx, cfg, paths, opts, client, c)
 	}
 
-	// Determine branch (use default branch from repo)
-	branch, err := client.GetDefaultBranch(ctx, owner, repo)
+	// Determine branch: explicit --branch override, else the repo's default.
+	branch, err := resolveBranch(ctx, client, owner, repo, opts.branch)
 	if err != nil {
 		return errors.GitHubFetchFailed(owner+"/"+repo, err)
 	}

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -500,4 +501,13 @@ Use gofmt.`
 
 	// Verify header
 	assert.Contains(t, outputStr, "Managed by staghorn", "output should contain staghorn header")
+}
+
+func TestResolveBranchUsesOverride(t *testing.T) {
+	// When an explicit branch is given, resolveBranch returns it without
+	// contacting GitHub. Passing a nil client proves the default-branch lookup
+	// is bypassed: any call on the nil client would panic.
+	branch, err := resolveBranch(context.Background(), nil, "owner", "repo", "feature-x")
+	require.NoError(t, err)
+	assert.Equal(t, "feature-x", branch)
 }


### PR DESCRIPTION
## What

Adds `stag sync --branch <name>` to sync the config from a specific branch instead of the repository's default branch. Handy for testing standards changes on a branch before merging them to the default branch.

## Why

`runSync` currently always resolves the branch via `GetDefaultBranch`, with no way to override it. The GitHub client already accepts a `?ref=<branch>` argument on `FetchFile`/`ListDirectory`/`FileExists` - this just wires a flag through to it.

## How

- New `--branch` flag on `stag sync`, plumbed through a small `resolveBranch` helper (explicit override, else the repo default).
- An explicit `--branch` always fetches. The cache is keyed by `owner/repo`, not by branch, so the cache-freshness short-circuit is skipped when `--branch` is set - otherwise a fresh default-branch cache would silently serve the wrong content for a branch request.
- `--branch` is rejected for multi-source configurations, since a single branch can't meaningfully apply across multiple source repos.
- Unit test covering the override path; README CLI reference and CHANGELOG updated.